### PR TITLE
feat(global): automatically update env.d.ts

### DIFF
--- a/.changeset/yellow-dogs-double.md
+++ b/.changeset/yellow-dogs-double.md
@@ -1,0 +1,5 @@
+---
+"astro-global": minor
+---
+
+The integration now automatically updates your project types to include the "astro:global" module.

--- a/packages/global/README.md
+++ b/packages/global/README.md
@@ -59,14 +59,6 @@ export default function () {
 ```
 Note that the Astro global is only usable on the server. This means that the component using it must not have a [client directive](https://docs.astro.build/en/reference/directives-reference/#client-directives). If you need data from the Astro global to be available to interactive components, manually provide the relevant data as props so that it can be serialized and sent to the client.
 
-### Intellisense and Typescript Support
-
-For typescript support for the virtual module `"astro:global"`, add the following line to `src/env.d.ts`.
-```diff lang="ts" "declare module 'astro:global';"
-/// <reference types="astro/client" />
-+ /// <reference types="astro-global/client" />
-```
-
 ## Troubleshooting
 
 For help, check out the `Discussions` tab on the [GitHub repo](https://github.com/lilnasy/gratelets/discussions).

--- a/packages/global/integration.ts
+++ b/packages/global/integration.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs"
 import type { AstroConfig, AstroIntegration } from "astro"
 
 interface Options {}
@@ -6,24 +7,46 @@ export default function (options: Partial<Options> = {}): AstroIntegration {
     return {
         name: "astro-global",
         hooks: {
-            "astro:config:setup": ({ addMiddleware, updateConfig }) => {
+            "astro:config:setup": ({ addMiddleware, updateConfig, config, logger }) => {
                 addMiddleware({
                     entrypoint: "astro-global/runtime/middleware.ts",
                     order: "pre"
                 })
 
-                const config: Partial<AstroConfig> = {
+                const extraConfig: Partial<AstroConfig> = {
                     vite: {
                         plugins: [{
                             name: "astro-global",
                             resolveId(source) {
                                 if (source === "astro:global") return this.resolve("astro-global/runtime/virtual-module.ts")
                             }
+                        }, {
+                            name: "astro-global-inject-env-ts",
+                            enforce: "post",
+                            config() {
+                                const envTsPath = new URL("env.d.ts", config.srcDir)
+                                
+                                let typesEnvContents: string
+                                try { typesEnvContents = fs.readFileSync(envTsPath, "utf-8") }
+                                catch { return }
+
+                                if (typesEnvContents.includes('/// <reference types="astro-global/client" />')) { return }
+                                
+                                const newTypesEnvContents = typesEnvContents.replace(
+                                    '/// <reference types="astro/client" />',
+                                    '/// <reference types="astro/client" />\n/// <reference types="astro-global/client" />'
+                                )
+                                
+                                if (newTypesEnvContents === typesEnvContents) { return }
+
+                                fs.writeFileSync(envTsPath, newTypesEnvContents)
+                                logger.info("Updated env.d.ts types")
+                            }
                         }]
                     }
                 }
 
-                updateConfig(config)
+                updateConfig(extraConfig)
             }
         }
     }

--- a/packages/global/tsconfig.json
+++ b/packages/global/tsconfig.json
@@ -1,3 +1,3 @@
 {
-    "extends": "./node_modules/astro/tsconfigs/strict.json"
+    "extends": "astro/tsconfigs/strict"
 }


### PR DESCRIPTION
# Changes
- `/// <reference types="astro-global/client" />` is now automatically added to `env.d.ts` if it is not in there already.

# Testing
Manual

# Docs
Removed section guiding through the manual process