### PR TITLE
new integration: dynamic import

### DIFF
--- a/packages/dynamic-import/README.md
+++ b/packages/dynamic-import/README.md
@@ -1,0 +1,69 @@
+# astro-dynamic-import 👩‍🎤
+
+This **[Astro integration][astro-integration]** lets you import components dynamically, allowing you to pick and choose which components add their scripts and styles to the page. Now you can let a CMS or DB query decide your components without astro sending JS and CSS for all of them!
+
+- <strong>[Why Import Dynamically](#why-import-dynamically)</strong>
+- <strong>[Installation](#installation)</strong>
+- <strong>[Usage](#usage)</strong>
+- <strong>[Troubleshooting](#troubleshooting)</strong>
+- <strong>[Contributing](#contributing)</strong>
+- <strong>[Changelog](#changelog)</strong>
+
+## Why Import Dynamically?
+
+Astro decides which scripts and styles get included on the page based on the import statements alone. If different components are picked based on the request, this heuristic quickly results in too many assets being sent to the browser. Importing dynamically lets you import components based on a condition and only the rendered components will send their associated assets to the browser.
+
+## Installation
+
+### Manual Install
+
+First, install the `astro-dynamic-import` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
+
+```sh
+npm install astro-dynamic-import
+```
+Next, apply this integration to your `astro.config.*` file using the `integrations` property:
+
+```diff lang="js" "dynamicImport()"
+  // astro.config.mjs
+  import { defineConfig } from 'astro/config';
++ import dynamicImport() from 'astro-dynamic-import';
+
+  export default defineConfig({
+    // ...
+    integrations: [dynamicImport()],
+    //             ^^^^^^^^^^^^^
+  });
+```
+
+## Usage
+
+Once the integration is installed and added to the configuration file, you can import the default function from the `"astro:import"` namespace.
+
+```astro
+---
+import dynamic from "astro:import"
+const toImport = random() ? "components/Counter.astro" : "components/Ticker.astro"
+const Component = await dynamic(toImport)
+const initial = 3
+---
+<Component {initial} />
+```
+
+The `dynamic` function takes the path to a component relative to your source directory (`"/src"` by default). It returns a promise that resolves to the astro component.
+
+Note that only `.astro` components can be imported. The components must be located in the `src/components` folder.
+
+## Troubleshooting
+
+For help, check out the `Discussions` tab on the [GitHub repo](https://github.com/lilnasy/gratelets/discussions).
+
+## Contributing
+
+This package is maintained by [lilnasy](https://github.com/lilnasy) independently from Astro. The integration code is located at [packages/dynamic-import/integration.ts](https://github.com/lilnasy/gratelets/blob/main/packages/dynamic-import/integration.ts). You're welcome to contribute by opening a PR or submitting an issue!
+
+## Changelog
+
+See [CHANGELOG.md](https://github.com/lilnasy/gratelets/blob/main/packages/dynamic-import/CHANGELOG.md) for a history of changes to this integration.
+
+[astro-integration]: https://docs.astro.build/en/guides/integrations-guide/

--- a/packages/dynamic-import/client.d.ts
+++ b/packages/dynamic-import/client.d.ts
@@ -1,0 +1,5 @@
+type AstroComponentFactory = import("astro/runtime/server/index.js").AstroComponentFactory
+
+declare module "astro:import" {
+    export default function (specifier: string): Promise<AstroComponentFactory>
+}

--- a/packages/dynamic-import/integration.ts
+++ b/packages/dynamic-import/integration.ts
@@ -1,0 +1,66 @@
+import url from "node:url"
+import path from "node:path"
+import fs from "node:fs"
+import type { AstroConfig, AstroIntegration, AstroIntegrationLogger } from "astro"
+import { PROPAGATED_ASSET_FLAG } from "./node_modules/astro/dist/content/consts.js"
+
+interface Options {}
+
+export default function (_?: Options): AstroIntegration {
+    return {
+        name: "adds-dynamic-import",
+        hooks: {
+            "astro:config:setup" ({ config, updateConfig, logger }) {
+                const srcDirName = path.relative(url.fileURLToPath(config.root), url.fileURLToPath(config.srcDir)).replaceAll("\\", "/")
+                updateConfig({ vite: { plugins: [{
+                    name: "adds-dynamic-import/vite",
+                    resolveId(source) {
+                        if (source === "astro:import") { return this.resolve("astro-dynamic-import/runtime/virtual-module.ts") }
+                        if (source === "astro-dynamic-import:internal") return source
+                    },
+                    load(id) {
+                        if (id === "astro-dynamic-import:internal") {
+                            return `export const srcDirName = ${JSON.stringify(srcDirName)}\n` +
+                            `export const lookupMap = import.meta.glob('/${srcDirName}/components/**/*.astro', { query: { ${PROPAGATED_ASSET_FLAG}: true } })\n`
+                        }
+                    }
+                }, {
+                    name: "astro-dynamic-import/vite/types",
+                    enforce: "post",
+                    async config() {
+                        injectEnvDTS(config, logger, "astro-dynamic-import/client")
+                    }
+                }] } })
+            }
+        }
+    }
+}
+
+function injectEnvDTS(config: AstroConfig, logger: AstroIntegrationLogger, specifier: URL | string) {
+    const envDTsPath = url.fileURLToPath(new URL("env.d.ts", config.srcDir))
+    
+    if (specifier instanceof URL) {
+        specifier = url.fileURLToPath(specifier)
+        specifier = path.relative(url.fileURLToPath(config.srcDir), specifier)
+        specifier = specifier.replaceAll("\\", "/")
+    }
+    
+    let envDTsContents = fs.readFileSync(envDTsPath, "utf-8")
+    
+    if (envDTsContents.includes(`/// <reference types='${specifier}' />`)) { return }
+    if (envDTsContents.includes(`/// <reference types="${specifier}" />`)) { return }
+    
+    const newEnvDTsContents = envDTsContents.replace(
+        `/// <reference types='astro/client' />`,
+        `/// <reference types='astro/client' />\n/// <reference types='${specifier}' />\n`
+    ).replace(
+        `/// <reference types="astro/client" />`,
+        `/// <reference types="astro/client" />\n/// <reference types="${specifier}" />\n`
+    )
+    
+    // the odd case where the user changed the reference to astro/client
+    if (newEnvDTsContents === envDTsContents) { return }
+    
+    fs.writeFileSync(envDTsPath, newEnvDTsContents)
+    logger.info("Updated env.d.ts types")
+}

--- a/packages/dynamic-import/package.json
+++ b/packages/dynamic-import/package.json
@@ -1,7 +1,7 @@
 {
     "name": "astro-dynamic-import",
     "version": "0.1.0",
-    "description": "",
+    "description": "Let your CMS decide which components to import.",
     "author": "Arsh",
     "license": "Public Domain",
     "keywords": [

--- a/packages/dynamic-import/package.json
+++ b/packages/dynamic-import/package.json
@@ -1,0 +1,38 @@
+{
+    "name": "astro-dynamic-import",
+    "version": "0.1.0",
+    "description": "",
+    "author": "Arsh",
+    "license": "Public Domain",
+    "keywords": [
+        "withastro",
+        "astro-component"
+    ],
+    "homepage": "https://github.com/lilnasy/gratelets/tree/main/packages/dynamic-import",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/lilnasy/gratelets",
+        "directory": "packages/dynamic-import"
+    },
+    "files": [
+        "integration.ts"
+    ],
+    "exports": {
+        ".": "./integration.ts",
+        "./runtime/*": "./runtime/*",
+        "./client": {
+            "types": "./client.d.ts"
+        }
+    },
+    "scripts": {
+        "test": "pnpm -w test tests/dynamic-import.test.ts"
+    },
+    "type": "module",
+    "peerDependencies": {
+        "astro": "4"
+    },
+    "devDependencies": {
+        "@types/node": "20",
+        "astro": "4"
+    }
+}

--- a/packages/dynamic-import/runtime/virtual-module.ts
+++ b/packages/dynamic-import/runtime/virtual-module.ts
@@ -1,0 +1,73 @@
+import path from "node:path"
+import {
+    createComponent,
+    createHeadAndContent,
+    renderComponent,
+    renderTemplate,
+    renderUniqueStylesheet,
+    renderScriptElement,
+    unescapeHTML,
+    type AstroComponentFactory
+} from "astro/runtime/server/index.js"
+//@ts-expect-error
+import { srcDirName, lookupMap as _lookupMap } from "astro-dynamic-import:internal"
+import type { SSRResult } from "astro"
+
+const lookupMap: Record<string, Promise<AstroComponentFactory>> = {}
+
+export default async function(srcRelativeSpecifier: string) {
+    const absoluteSpecifier = path.posix.join("/", srcDirName, srcRelativeSpecifier)
+    const component = lookupMap[absoluteSpecifier]
+    if (component === undefined) throw new DynamicImportError(srcRelativeSpecifier, absoluteSpecifier)
+    return component
+}
+
+for (const absoluteSpecifier in _lookupMap) {
+    const importable = _lookupMap[absoluteSpecifier]
+    Object.assign(lookupMap, {
+        get [absoluteSpecifier]() {
+            lookupMap[absoluteSpecifier] = lazyImportToComponent(absoluteSpecifier, importable)
+            return lookupMap[absoluteSpecifier]
+        }
+    })
+}
+
+async function lazyImportToComponent(absoluteSpecifier: string, importable: any) {
+    const entry = await importable()
+    const { collectedStyles, collectedLinks, collectedScripts, getMod } = entry.default
+    const componentModule = await getMod()
+    return createComponent({
+        factory(result: SSRResult, props: Record<string, unknown>, slots: Record<string, unknown>) {
+            const component = componentModule.default
+            const styles = collectedStyles.map((style: any) => renderUniqueStylesheet(result, { type: 'inline', content: style })).join('')
+            const links = collectedLinks.map((link: any) => renderUniqueStylesheet(result, { type: 'external', src: prependForwardSlash(link) })).join('')
+            const scripts = collectedScripts.map((script: any) => renderScriptElement(script)).join('')
+            return createHeadAndContent(unescapeHTML(styles + links + scripts) as any,
+                renderTemplate`${renderComponent(
+                    result,
+                    `dynamically-imported:${component.name}`,
+                    component,
+                    props,
+                    slots
+                )}`
+            )
+        },
+        moduleId: `dynamically-imported:${absoluteSpecifier}`,
+        propagation: "self"
+    })
+}
+
+class DynamicImportError extends Error {
+    name = "DynamicImportError"
+    constructor(unmatchedComponent: string, processedSpecifier: string) {
+        let message = ''
+        message += `Could not dynamically import '${unmatchedComponent}'\n`
+        message += `'${processedSpecifier}' was not one of the following:\n`
+        message += `${Object.keys(_lookupMap).map((specifier) => `  - ${specifier}`).join("\n")}`
+        super(message)
+    }
+}
+
+function prependForwardSlash(path: string) {
+    return path[0] === "/" ? path : "/" + path;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,15 @@ importers:
         specifier: '4'
         version: 4.0.3(@types/node@20.10.4)(typescript@5.3.3)
 
+  packages/dynamic-import:
+    devDependencies:
+      '@types/node':
+        specifier: '20'
+        version: 20.10.4
+      astro:
+        specifier: '4'
+        version: 4.0.3(@types/node@20.10.4)(typescript@5.3.3)
+
   packages/emotion:
     dependencies:
       '@emotion/css':
@@ -115,6 +124,15 @@ importers:
       astro-adds-to-head:
         specifier: workspace:*
         version: link:../../../packages/adds-to-head
+
+  tests/fixtures/dynamic-import:
+    dependencies:
+      astro:
+        specifier: '4'
+        version: 4.0.3(@types/node@20.10.4)(typescript@5.3.3)
+      astro-dynamic-import:
+        specifier: workspace:*
+        version: link:../../../packages/dynamic-import
 
   tests/fixtures/emotion:
     dependencies:

--- a/tests/dynamic-import.test.ts
+++ b/tests/dynamic-import.test.ts
@@ -1,0 +1,128 @@
+import { describe, beforeAll, test, expect } from "vitest"
+import { build, dev, type BuildFixture, type DevServer } from "./utils.ts"
+
+const buildScriptRegex = /(?<=<script src=")[\-/_.?&#;=a-zA-Z0-9]*(?=" type="module"><\/script>)/
+const devScriptRegex = /(?<=<script type="module" src=")[\-/_.?&=#;a-zA-Z0-9]*(?="><\/script>)/
+
+describe("build", () => {
+    let fixture: BuildFixture
+    let A: string
+    let B: string
+    let C: string
+    let D: string
+    
+    beforeAll(async () => {
+        fixture = await build("./fixtures/dynamic-import")
+        A = fixture.readTextFile("A/index.html")
+        B = fixture.readTextFile("B/index.html")
+        C = fixture.readTextFile("C/index.html")
+        D = fixture.readTextFile("D/index.html")
+    })
+    
+    test("Page A includes styles and scripts from component A", async () => {
+        expect(A).to.include("Contents of A")
+        expect(A).to.include("background-color:#afeeee")
+        const match = buildScriptRegex.exec(A)
+        expect(match).to.not.be.null
+        const [ src ] = match!
+        const js = fixture.readTextFile(`.${src}`)
+        expect(js).to.include("script of A")
+    })
+    
+    test("Page B includes styles and scripts from component B", async () => {
+        expect(B).to.include("Contents of B")
+        expect(B).to.include("background-color:#fff8dc")
+        const match = buildScriptRegex.exec(B)
+        expect(match).to.not.be.null
+        const [ src ] = match!
+        const js = fixture.readTextFile(`.${src}`)
+        expect(js).to.include("script of B")
+    })
+    
+    test("Assets don't leak into unrelated pages", async () => {
+        expect(A).to.not.include("background-color:#fff8dc")
+        expect(B).to.not.include("background-color:#afeeee")
+        const matches = [...A.matchAll(new RegExp(buildScriptRegex, "g"))]
+        expect(matches).to.not.be.empty
+        expect(matches).to.have.lengthOf(1)
+        const [ scriptA ] = matches!
+        {
+            const matches = [...B.matchAll(new RegExp(buildScriptRegex, "g"))]
+            expect(matches).to.have.lengthOf(1)
+            const [ scriptB ] = matches!
+            expect(scriptA).to.not.equal(scriptB)
+        }
+    })
+
+    test("Components in a subfolder can be dynamically imported", async () => {
+        expect(C).to.include("Contents of C")
+        expect(C).to.include("background-color:#deb887")
+        const [ src ] = buildScriptRegex.exec(C)!
+        const js = fixture.readTextFile(`.${src}`)
+        expect(js).to.include("script of C")
+    })
+
+    test("Props can be sent to the component", () => {
+        expect(D).to.include("<div>0</div><div>1</div><div>2</div><div>3</div><div>4</div>")
+    })
+})
+
+describe("dev", () => {
+    let server: DevServer
+    let A: string
+    let B: string
+    
+    beforeAll(async () => {
+        server = await dev("./fixtures/dynamic-import")
+    })
+    
+    test("Page A includes styles and scripts from component A", async () => {
+        A = await server.fetch("/A")
+        expect(A).to.include("Contents of A")
+        expect(A).to.include("background-color:paleturquoise")
+        const [ src ] = devScriptRegex.exec(A)!
+        const js = await server.fetch(src)
+        expect(js).to.include("script of A")
+    })
+    
+    test("Page B includes styles and scripts from component B", async () => {
+        B = await server.fetch("/B")
+        expect(B).to.include("Contents of B")
+        expect(B).to.include("background-color:cornsilk")
+        const [ src ] = devScriptRegex.exec(B)!
+        const js = await server.fetch(src)
+        expect(js).to.include("script of B")
+    })
+    
+    test("Assets don't leak into unrelated pages", async () => {
+        expect(A).to.not.include("background-color:#fff8dc")
+        expect(B).to.not.include("background-color:#afeeee")
+        const matches = devScriptRegex.exec(A)
+        expect(matches).to.have.lengthOf(1)
+        const [ scriptA ] = matches!
+        {
+            const matches = devScriptRegex.exec(B)
+            expect(matches).to.have.lengthOf(1)
+            const [ scriptB ] = matches!
+            expect(scriptA).to.not.equal(scriptB)
+        }
+    })
+
+    test("Components in a subfolder can be dynamically imported", async () => {
+        const C = await server.fetch("/C")
+        expect(C).to.include("Contents of C")
+        expect(C).to.include("background-color:burlywood")
+        const [ src ] = devScriptRegex.exec(C)!
+        const js = await server.fetch(src)
+        expect(js).to.include("script of C")
+    })
+
+    test("Props can be sent to the component", async () => {
+        const D = await server.fetch("/D")
+        expect(D).to.include("0</div>")
+        expect(D).to.include("1</div>")
+        expect(D).to.include("2</div>")
+        expect(D).to.include("3</div>")
+        expect(D).to.include("4</div>")
+    })
+})

--- a/tests/fixtures/dynamic-import/astro.config.ts
+++ b/tests/fixtures/dynamic-import/astro.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "astro/config"
+import dynamicImport from "astro-dynamic-import"
+
+// https://astro.build/config
+export default defineConfig({
+    integrations: [dynamicImport()]
+})

--- a/tests/fixtures/dynamic-import/package.json
+++ b/tests/fixtures/dynamic-import/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "@test/dynamic-import",
+    "private": true,
+    "dependencies": {
+        "astro": "4",
+        "astro-dynamic-import": "workspace:*"
+    }
+}

--- a/tests/fixtures/dynamic-import/src/components/A.astro
+++ b/tests/fixtures/dynamic-import/src/components/A.astro
@@ -1,0 +1,9 @@
+<p>Contents of A</p>
+<style>
+    p {
+        background-color: paleturquoise
+    }
+</style>
+<script>
+    console.log("script of A")
+</script>

--- a/tests/fixtures/dynamic-import/src/components/B.astro
+++ b/tests/fixtures/dynamic-import/src/components/B.astro
@@ -1,0 +1,9 @@
+<p>Contents of B</p>
+<style>
+    p {
+        background-color: cornsilk
+    }
+</style>
+<script>
+    console.log("script of B")
+</script>

--- a/tests/fixtures/dynamic-import/src/components/in-a-folder/C.astro
+++ b/tests/fixtures/dynamic-import/src/components/in-a-folder/C.astro
@@ -1,0 +1,9 @@
+<p>Contents of C</p>
+<style>
+    p {
+        background-color: burlywood;
+    }
+</style>
+<script>
+    console.log("script of C")
+</script>

--- a/tests/fixtures/dynamic-import/src/components/needs-props.astro
+++ b/tests/fixtures/dynamic-import/src/components/needs-props.astro
@@ -1,0 +1,8 @@
+---
+interface Props {
+    x: number;
+}
+const { x } = Astro.props
+if (!x) throw new Error('x is required')
+---
+{Array.from({ length: x }).map((_, i) => <div>{i}</div>)}

--- a/tests/fixtures/dynamic-import/src/pages/[page].astro
+++ b/tests/fixtures/dynamic-import/src/pages/[page].astro
@@ -1,0 +1,21 @@
+---
+import type { GetStaticPaths } from "astro"
+import dynamic from "astro:import"
+
+interface Props {
+    component: "A" | "B"
+}
+
+export function getStaticPaths(): ReturnType<GetStaticPaths> {
+    return [
+        { params: { page: "A" }, props: { component: "A" } },
+        { params: { page: "B" }, props: { component: "B" } },
+        { params: { page: "C" }, props: { component: "in-a-folder/C" } },
+        { params: { page: "D" }, props: { component: "needs-props" } }
+    ]
+}
+
+const { component } = Astro.props
+const Component = await dynamic(`components/${component}.astro`)
+---
+<Component x={5}/>


### PR DESCRIPTION
# Changes

- Introduces an integration that allows you to dynamically import astro components without CSS & JS of all of them being included in the page.

# Testing

- Added a fixture
<img width="593" alt="image" src="https://github.com/lilnasy/gratelets/assets/69170106/ce898877-c210-46e8-9706-b1dad3355889">


# Docs

- Added a readme
