### PR TITLE
fix(stylex): allow vite to reload css

### DIFF
--- a/.changeset/neat-fireants-wash.md
+++ b/.changeset/neat-fireants-wash.md
@@ -1,0 +1,5 @@
+---
+"astro-stylex": patch
+---
+
+Fixes an issue where even after a full-page refresh, stale stylesheets were used.

--- a/packages/stylex/integration.ts
+++ b/packages/stylex/integration.ts
@@ -22,17 +22,19 @@ export default function (_: Partial<Options> = {}): AstroIntegration {
                         }) as any
                         if (result?.metadata?.stylex?.length > 0 === false) return
                         stylesheets[id] = result.metadata.stylex
-                        const newCode = result.code + `\nimport "${id}.astro_stylex_internal.css"\n`
+                        const newCode = result.code + `\nimport "${id}.astro_stylex_internal.css?time=${Date.now()}&astro-stylex&lang.css"\n`
                         const map = result.map
                         const metadata = result.metadata
                         return { code: newCode, map, meta: metadata }
                     },
                     resolveId(source) {
-                        if (source.endsWith(".astro_stylex_internal.css")) return source
+                        if (source.endsWith("astro-stylex&lang.css")) return source
                     },
                     async load(id) {
-                        if (id.endsWith(".astro_stylex_internal.css")) {
-                            const sourceFileId = id.slice(0, -".astro_stylex_internal.css".length)
+                        const [source, query] = id.split(`?`, 2)
+                        const params = new URLSearchParams(query)
+                        if (params.has("astro-stylex")) {
+                            const sourceFileId = source.slice(0, -".astro_stylex_internal.css".length)
                             const { id: resolvedId } = await this.resolve(sourceFileId) ?? {}
                             if (resolvedId === undefined) return logger.error("Could not find the real path for " + sourceFileId)
                             const generatedCss = stylesheets[resolvedId]

--- a/packages/stylex/package.json
+++ b/packages/stylex/package.json
@@ -24,7 +24,7 @@
         }
     },
     "scripts": {
-        "test": "pnpm -w test tests/stylex.dev.test.ts tests/stylex.build.test.ts"
+        "test": "pnpm -w test stylex.test.ts"
     },
     "type": "module",
     "peerDependencies": {

--- a/tests/hono/adapter-middleware.test.ts
+++ b/tests/hono/adapter-middleware.test.ts
@@ -10,7 +10,7 @@ test("standalone mode - 404 page", async ({ cheerio, expect, server }) => {
     const body = $("body")
     expect(body.text()).to.equal("Page does not exist")
     await server.destroy()
-})
+}, { timeout: 10000 })
 
 test("middleware mode - on-demand rendered page", async ({ cheerio, expect, hono }) => {
     const res = await hono.fetch(new Request("http://example.com/ssr"))

--- a/tests/hono/image.test.ts
+++ b/tests/hono/image.test.ts
@@ -6,4 +6,4 @@ test("it can optimize and serve images", async ({ expect, server }) => {
     const resImage = await fetch("http://localhost:4321/_image?href=/_astro/some_penguin.9PDPbedL.png&w=50&f=webp")
     expect(resImage.status).to.equal(200)
     await server.destroy()
-})
+}, { timeout: 10000 })


### PR DESCRIPTION
# Changes
- Fixes #40
- **Background**: `load()` hook is called only once per path and reused from there.
- **Fix**: add `time` query param to the path generated from the current time.

# Testing
- Dev fix, manually tested.

# Docs
Does not affect usage.