### PR TITLE
new integration: json schema for data collections

### DIFF
--- a/packages/json-schema/integration.ts
+++ b/packages/json-schema/integration.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs"
+import { fileURLToPath } from "node:url"
+import { createServer} from "vite"
+import {
+	createContentTypesGenerator,
+	createNodeLogger,
+	createVite,
+	createSettings,
+	globalContentConfigObserver,
+	resolveConfig,
+	type ContentConfig
+} from "./utils.ts"
+import { zodToJsonSchema } from "zod-to-json-schema"
+import type { AstroIntegration } from "astro"
+
+export interface Options {}
+
+export default function(_?: Partial<Options>): AstroIntegration {
+    return {
+        name: "astro-integration-json-schema",
+        hooks: {
+            async "astro:config:setup" ({ config }) {
+                const { collections } = await getCollectionDefinitions()
+				for (const key in collections) {
+					const collection = collections[key]
+					if (collection.type !== "data") continue
+					const schema = zodToJsonSchema(collection.schema)
+					const json = JSON.stringify(schema, null, 4)
+					fs.writeFileSync(new URL(`./.astro/${key}.schema.json`, config.root), json)
+				}
+            }
+        }
+    }
+}
+
+async function getCollectionDefinitions(): Promise<ContentConfig> {
+    const logger = createNodeLogger({ logLevel: "silent" })
+	const { astroConfig } = await resolveConfig({}, "sync")
+
+	const settings = await createSettings(astroConfig, fileURLToPath(astroConfig.root))
+
+	const tempViteServer = await createServer(
+		await createVite(
+			{
+				server: { middlewareMode: true, hmr: false, watch: { ignored: ["**"] } },
+				optimizeDeps: { disabled: true },
+				ssr: { external: [] },
+				logLevel: "silent",
+			},
+			{ settings, logger, mode: "build", command: "build", fs }
+		)
+	)
+	try {
+		const contentTypesGenerator = await createContentTypesGenerator({
+			contentConfigObserver: globalContentConfigObserver,
+			logger: logger,
+			fs,
+			settings,
+			viteServer: tempViteServer,
+		})
+		
+        await contentTypesGenerator.init()
+
+		const contentConfig = globalContentConfigObserver.get()
+		if (contentConfig.status === "loaded") {
+			return contentConfig.config
+		}
+        else throw new Error("Could not load content/config.ts", { cause: contentConfig })
+	} catch (e) {
+		console.error(e)
+	} finally {
+		await tempViteServer.close()
+	}
+}

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "astro-json-schema",
+    "version": "0.0.0",
+    "exports": {
+        ".": "./integration.ts"
+    },
+    "dependencies": {
+        "astro": "4",
+        "vite": "5",
+        "zod-to-json-schema": "3"
+    }
+}

--- a/packages/json-schema/utils.ts
+++ b/packages/json-schema/utils.ts
@@ -1,0 +1,7 @@
+export { createContentTypesGenerator } from "./node_modules/astro/dist/content/index.js"
+export { globalContentConfigObserver } from "./node_modules/astro/dist/content/utils.js"
+export { resolveConfig } from "./node_modules/astro/dist/core/config/config.js"
+export { createNodeLogger } from "./node_modules/astro/dist/core/config/logging.js"
+export { createSettings } from "./node_modules/astro/dist/core/config/settings.js"
+export { createVite } from "./node_modules/astro/dist/core/create-vite.js"
+export type { ContentConfig } from "./node_modules/astro/dist/content/utils.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         specifier: '5'
         version: 5.0.7(@types/node@20.10.4)
       zod-to-json-schema:
-        specifier: ^3.22.3
+        specifier: '3'
         version: 3.22.3(zod@3.22.4)
 
   packages/prerender-patterns:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,18 @@ importers:
         specifier: '4'
         version: 4.0.3(@types/node@20.10.4)(typescript@5.3.3)
 
+  packages/json-schema:
+    dependencies:
+      astro:
+        specifier: '4'
+        version: 4.0.3(@types/node@20.10.4)(typescript@5.3.3)
+      vite:
+        specifier: '5'
+        version: 5.0.7(@types/node@20.10.4)
+      zod-to-json-schema:
+        specifier: ^3.22.3
+        version: 3.22.3(zod@3.22.4)
+
   packages/prerender-patterns:
     devDependencies:
       '@types/node':
@@ -6806,6 +6818,14 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+
+  /zod-to-json-schema@3.22.3(zod@3.22.4):
+    resolution: {integrity: sha512-9isG8SqRe07p+Aio2ruBZmLm2Q6Sq4EqmXOiNpDxp+7f0LV6Q/LX65fs5Nn+FV/CzfF3NLBoksXbS2jNYIfpKw==}
+    peerDependencies:
+      zod: ^3.22.4
+    dependencies:
+      zod: 3.22.4
+    dev: false
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}


### PR DESCRIPTION
# Intro

- Reads `content/config.ts` for data collections every time `astro sync` runs.
- Converts the zod schema to json schema using [`zod-to-json-schema`](https://www.npmjs.com/package/zod-to-json-schema) 
- Writes each schema to `<root>/.astro/<collection>.schema.json` where `<root>` is the directory where `package.json` and `astro.config.mjs` usually go, and `<collection>` is the name of the data collection as read from the exported `collections` value.