### PR TITLE
breaking(typed api): support for trailingSlash

### DIFF
--- a/.changeset/tiny-zoos-whisper.md
+++ b/.changeset/tiny-zoos-whisper.md
@@ -1,0 +1,7 @@
+---
+"astro-typed-api": minor
+---
+
+**Breaking change**: The minimum required astro version is now 4.1.
+
+Fixes an issue where having trailingSlash configured prevented API calls from being routed correctly.

--- a/packages/typed-api/integration.ts
+++ b/packages/typed-api/integration.ts
@@ -24,7 +24,17 @@ export default function (_?: Partial<Options>): AstroIntegration {
                         generateTypes(filenames, apiDir, declarationFileUrl)
                     }
                 }] } })
-                updateConfig({ vite: { ssr: { noExternal: ["astro-typed-api"] } } })
+                updateConfig({
+                    vite: {
+                        define: {
+                            "import.meta.env._TRAILING_SLASH": JSON.stringify(config.trailingSlash)
+                        },
+                        ssr: {
+                            // this package is published as uncompiled typescript, which we need vite to process
+                            noExternal: ["astro-typed-api"]
+                        }
+                    }
+                })
             },
             "astro:server:setup" ({ server }) {
                 server.watcher.on("add", async path => {

--- a/packages/typed-api/package.json
+++ b/packages/typed-api/package.json
@@ -31,6 +31,7 @@
     },
     "type": "module",
     "peerDependencies": {
+        "astro": "^4.1.0",
         "zod": "3"
     },
     "dependencies": {

--- a/packages/typed-api/runtime/client-internals.ts
+++ b/packages/typed-api/runtime/client-internals.ts
@@ -44,11 +44,9 @@ async function callServer(segments: string[], method_: string, input: any, optio
     if (import.meta.env.BASE_URL !== "/") {
         pathname_ = (import.meta.env.BASE_URL + pathname_).split("/").filter(Boolean).join("/")
     }
-    // apparently trailing slashes are not handled by astro router
-    // /x/ would fail to match pages/x.ts despite trailingSlash being set to "always"
-    // if (import.meta.env._TRAILING_SLASH === "always") {
-    //     if (pathname_.endsWith("/") === false) pathname_ += "/"
-    // }
+    if (import.meta.env._TRAILING_SLASH === "always") {
+        if (pathname_.endsWith("/") === false) pathname_ += "/"
+    }
     const pathname = pathname_
     const method = method_ === "ALL" ? options.method : method_
     if (method === undefined) throw new MissingHTTPVerb(pathname)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 2.27.1
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       typescript:
         specifier: '5.3'
         version: 5.3.3
@@ -28,13 +28,13 @@ importers:
         version: 20.10.6
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
 
   packages/dynamic-import:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
     devDependencies:
       '@types/node':
         specifier: '20'
@@ -57,13 +57,13 @@ importers:
         version: 20.10.6
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
 
   packages/global:
     dependencies:
       astro:
         specifier: ^3.5.2 || 4
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
     devDependencies:
       '@types/node':
         specifier: '20'
@@ -79,11 +79,11 @@ importers:
         version: 1.4.0
       hono:
         specifier: '3'
-        version: 3.11.12
+        version: 3.12.0
     devDependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
 
   packages/prerender-patterns:
     devDependencies:
@@ -92,13 +92,13 @@ importers:
         version: 20.10.6
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
 
   packages/scope:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
     devDependencies:
       '@types/node':
         specifier: '20'
@@ -124,7 +124,7 @@ importers:
         version: 20.10.6
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
 
   packages/typed-api:
     dependencies:
@@ -140,25 +140,25 @@ importers:
     devDependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
 
   tests:
     devDependencies:
       '@astrojs/node':
         specifier: '7'
-        version: 7.0.4(astro@4.0.9)
+        version: 7.0.4(astro@4.1.0)
       '@hono/node-server':
         specifier: '1'
         version: 1.4.0
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       cheerio:
         specifier: 1.0.0-rc.12
         version: 1.0.0-rc.12
       hono:
         specifier: '3'
-        version: 3.11.12
+        version: 3.12.0
       typescript:
         specifier: '5.3'
         version: 5.3.3
@@ -170,7 +170,7 @@ importers:
     devDependencies:
       '@astrojs/node':
         specifier: '7'
-        version: 7.0.4(astro@4.0.9)
+        version: 7.0.4(astro@4.1.0)
       playwright:
         specifier: '1'
         version: 1.40.1
@@ -179,10 +179,10 @@ importers:
     dependencies:
       '@astrojs/node':
         specifier: '7'
-        version: 7.0.4(astro@4.0.9)
+        version: 7.0.4(astro@4.1.0)
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-typed-api:
         specifier: workspace:*
         version: link:../../../packages/typed-api
@@ -194,10 +194,10 @@ importers:
     dependencies:
       '@astrojs/mdx':
         specifier: '2'
-        version: 2.0.3(astro@4.0.9)
+        version: 2.0.3(astro@4.1.0)
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-adds-to-head:
         specifier: workspace:*
         version: link:../../../packages/adds-to-head
@@ -206,7 +206,7 @@ importers:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-dynamic-import:
         specifier: workspace:*
         version: link:../../../packages/dynamic-import
@@ -215,16 +215,16 @@ importers:
     dependencies:
       '@astrojs/preact':
         specifier: '3'
-        version: 3.0.2(@babel/core@7.23.7)(preact@10.19.3)(vite@5.0.10)
+        version: 3.1.0(@babel/core@7.23.7)(preact@10.19.3)(vite@5.0.11)
       '@astrojs/react':
         specifier: '3'
-        version: 3.0.9(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)(vite@5.0.10)
+        version: 3.0.9(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)(vite@5.0.11)
       '@astrojs/solid-js':
         specifier: '3'
-        version: 3.0.3(solid-js@1.8.7)(vite@5.0.10)
+        version: 3.0.3(solid-js@1.8.8)(vite@5.0.11)
       '@astrojs/svelte':
         specifier: '5'
-        version: 5.0.3(astro@4.0.9)(svelte@4.2.8)(typescript@5.3.3)(vite@5.0.10)
+        version: 5.0.3(astro@4.1.0)(svelte@4.2.8)(typescript@5.3.3)(vite@5.0.11)
       '@preact/signals':
         specifier: '1'
         version: 1.2.2(preact@10.19.3)
@@ -236,7 +236,7 @@ importers:
         version: 18.2.18
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-emotion:
         specifier: workspace:*
         version: link:../../../packages/emotion
@@ -251,7 +251,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       solid-js:
         specifier: '1'
-        version: 1.8.7
+        version: 1.8.8
       svelte:
         specifier: '4'
         version: 4.2.8
@@ -260,13 +260,13 @@ importers:
     dependencies:
       '@astrojs/mdx':
         specifier: '2'
-        version: 2.0.3(astro@4.0.9)
+        version: 2.0.3(astro@4.1.0)
       '@astrojs/preact':
         specifier: '3'
-        version: 3.0.2(@babel/core@7.23.7)(preact@10.19.3)(vite@5.0.10)
+        version: 3.1.0(@babel/core@7.23.7)(preact@10.19.3)(vite@5.0.11)
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-global:
         specifier: workspace:*
         version: link:../../../packages/global
@@ -278,7 +278,7 @@ importers:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-hono:
         specifier: workspace:*
         version: link:../../../../packages/hono
@@ -287,7 +287,7 @@ importers:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-hono:
         specifier: workspace:*
         version: link:../../../../packages/hono
@@ -296,7 +296,7 @@ importers:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-hono:
         specifier: workspace:*
         version: link:../../../../packages/hono
@@ -305,7 +305,7 @@ importers:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-hono:
         specifier: workspace:*
         version: link:../../../../packages/hono
@@ -314,7 +314,7 @@ importers:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-hono:
         specifier: workspace:*
         version: link:../../../../packages/hono
@@ -323,7 +323,7 @@ importers:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-hono:
         specifier: workspace:*
         version: link:../../../../packages/hono
@@ -332,7 +332,7 @@ importers:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-hono:
         specifier: workspace:*
         version: link:../../../../packages/hono
@@ -344,7 +344,7 @@ importers:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-hono:
         specifier: workspace:*
         version: link:../../../../packages/hono
@@ -353,7 +353,7 @@ importers:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-hono:
         specifier: workspace:*
         version: link:../../../../packages/hono
@@ -362,7 +362,7 @@ importers:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-hono:
         specifier: workspace:*
         version: link:../../../../packages/hono
@@ -371,7 +371,7 @@ importers:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-hono:
         specifier: workspace:*
         version: link:../../../../packages/hono
@@ -380,7 +380,7 @@ importers:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-hono:
         specifier: workspace:*
         version: link:../../../../packages/hono
@@ -389,7 +389,7 @@ importers:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-prerender-patterns:
         specifier: workspace:*
         version: link:../../../packages/prerender-patterns
@@ -398,7 +398,7 @@ importers:
     dependencies:
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-scope:
         specifier: workspace:*
         version: link:../../../packages/scope
@@ -407,16 +407,16 @@ importers:
     dependencies:
       '@astrojs/preact':
         specifier: '3'
-        version: 3.0.2(@babel/core@7.23.7)(preact@10.19.3)(vite@5.0.10)
+        version: 3.1.0(@babel/core@7.23.7)(preact@10.19.3)(vite@5.0.11)
       '@astrojs/react':
         specifier: '3'
-        version: 3.0.9(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)(vite@5.0.10)
+        version: 3.0.9(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)(vite@5.0.11)
       '@astrojs/solid-js':
         specifier: '3'
-        version: 3.0.3(solid-js@1.8.7)(vite@5.0.10)
+        version: 3.0.3(solid-js@1.8.8)(vite@5.0.11)
       '@astrojs/svelte':
         specifier: '5'
-        version: 5.0.3(astro@4.0.9)(svelte@4.2.8)(typescript@5.3.3)(vite@5.0.10)
+        version: 5.0.3(astro@4.1.0)(svelte@4.2.8)(typescript@5.3.3)(vite@5.0.11)
       '@preact/signals':
         specifier: '1'
         version: 1.2.2(preact@10.19.3)
@@ -431,7 +431,7 @@ importers:
         version: 18.2.18
       astro:
         specifier: '4'
-        version: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       astro-stylex:
         specifier: workspace:*
         version: link:../../../packages/stylex
@@ -446,7 +446,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       solid-js:
         specifier: '1'
-        version: 1.8.7
+        version: 1.8.8
       svelte:
         specifier: '4'
         version: 4.2.8
@@ -460,8 +460,8 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.20
 
-  /@astrojs/compiler@2.3.4:
-    resolution: {integrity: sha512-33/YtWoBCE0cBUNy1kh78FCDXBoBANX87ShgATlAHECYbG2+buNTAgq4Xgz4t5NgnEHPN21GIBC2Mvvwisoutw==}
+  /@astrojs/compiler@2.4.0:
+    resolution: {integrity: sha512-LUN/iG8KcStfChHwTvCg/t91IQFQxguF3CkDLW3tdY2vBKZmOJy9MgtRl20ZGgPtgrykGCtnr4AellEm0bPuFg==}
 
   /@astrojs/internal-helpers@0.2.1:
     resolution: {integrity: sha512-06DD2ZnItMwUnH81LBLco3tWjcZ1lGU9rLCCBaeUCGYe9cI0wKyY2W3kDyoW1I6GmcWgt1fu+D1CTvz+FIKf8A==}
@@ -478,7 +478,7 @@ packages:
       remark-gfm: 4.0.0
       remark-parse: 11.0.0
       remark-rehype: 11.0.0
-      remark-smartypants: 2.0.0
+      remark-smartypants: 2.1.0
       shikiji: 0.6.13
       unified: 11.0.4
       unist-util-visit: 5.0.0
@@ -486,7 +486,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@astrojs/mdx@2.0.3(astro@4.0.9):
+  /@astrojs/mdx@2.0.3(astro@4.1.0):
     resolution: {integrity: sha512-wFjQX5CihU5B4UAQNwc2R48ph0flpc6/yvDCFANE0agtgI2+BaVcAjuW0EhGOQCZ65dQDqnFKE0lvGs7EADYpg==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
@@ -495,7 +495,7 @@ packages:
       '@astrojs/markdown-remark': 4.0.1
       '@mdx-js/mdx': 3.0.0
       acorn: 8.11.3
-      astro: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+      astro: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       es-module-lexer: 1.4.1
       estree-util-visit: 2.0.0
       github-slugger: 2.0.0
@@ -504,7 +504,7 @@ packages:
       kleur: 4.1.5
       rehype-raw: 7.0.0
       remark-gfm: 4.0.0
-      remark-smartypants: 2.0.0
+      remark-smartypants: 2.1.0
       source-map: 0.7.4
       unist-util-visit: 5.0.0
       vfile: 6.0.1
@@ -512,30 +512,31 @@ packages:
       - supports-color
     dev: false
 
-  /@astrojs/node@7.0.4(astro@4.0.9):
+  /@astrojs/node@7.0.4(astro@4.1.0):
     resolution: {integrity: sha512-og36WkHZ+v32filXWx2Iu9iwj6v9QUQaBl5GcTHVGmw1lrGdztl0MtbqbY56az4ew/HkWq3GPSSQ70aZd0u86Q==}
     peerDependencies:
       astro: ^4.0.0
     dependencies:
-      astro: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+      astro: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       send: 0.18.0
       server-destroy: 1.0.1
     transitivePeerDependencies:
       - supports-color
 
-  /@astrojs/preact@3.0.2(@babel/core@7.23.7)(preact@10.19.3)(vite@5.0.10):
-    resolution: {integrity: sha512-qQ9xoWqX9gwO2n7NVTp4umt5auDgaGtqdKmZMqif6bCuBr1yWpNjWyREb/22iQAcouveybC6wFfiQnC0ewAXzw==}
+  /@astrojs/preact@3.1.0(@babel/core@7.23.7)(preact@10.19.3)(vite@5.0.11):
+    resolution: {integrity: sha512-17Eo+H3fTgcmKUa7v6aAt2BIkffdTZGR4aC0K2jO4nyNhgLRAEuaoXXJwzAG1x0UHnCw7bTQ2Vv3vuJFRy1PTg==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       preact: ^10.6.5
     dependencies:
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.23.7)
       '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.23.7)
-      '@preact/preset-vite': 2.8.1(@babel/core@7.23.7)(preact@10.19.3)(vite@5.0.10)
+      '@preact/preset-vite': 2.8.1(@babel/core@7.23.7)(preact@10.19.3)(vite@5.0.11)
       '@preact/signals': 1.2.2(preact@10.19.3)
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.23.7)
       preact: 10.19.3
       preact-render-to-string: 6.3.1(preact@10.19.3)
+      preact-ssr-prepass: 1.2.1(preact@10.19.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -548,7 +549,7 @@ packages:
     dependencies:
       prismjs: 1.29.0
 
-  /@astrojs/react@3.0.9(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)(vite@5.0.10):
+  /@astrojs/react@3.0.9(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)(vite@5.0.11):
     resolution: {integrity: sha512-31J5yF5p9yBFV1axBooLA9PB4B2+MYm7swWhtlezSsJiUNXRFo5Is9qI3teJ7cKgmaCv+ZA593Smskko0NGaDQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
@@ -559,7 +560,7 @@ packages:
     dependencies:
       '@types/react': 18.2.46
       '@types/react-dom': 18.2.18
-      '@vitejs/plugin-react': 4.2.1(vite@5.0.10)
+      '@vitejs/plugin-react': 4.2.1(vite@5.0.11)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       ultrahtml: 1.5.2
@@ -568,28 +569,28 @@ packages:
       - vite
     dev: false
 
-  /@astrojs/solid-js@3.0.3(solid-js@1.8.7)(vite@5.0.10):
+  /@astrojs/solid-js@3.0.3(solid-js@1.8.8)(vite@5.0.11):
     resolution: {integrity: sha512-MS/SoKUNByBjclhXn004DEsfi4rDNrg0LVbjgSnVfGHrdjP1dQd5bnm0wah04QuhqJCfsIF0ba9c02qJhaj/2w==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       solid-js: ^1.4.3
     dependencies:
-      solid-js: 1.8.7
-      vite-plugin-solid: 2.8.0(solid-js@1.8.7)(vite@5.0.10)
+      solid-js: 1.8.8
+      vite-plugin-solid: 2.8.0(solid-js@1.8.8)(vite@5.0.11)
     transitivePeerDependencies:
       - supports-color
       - vite
     dev: false
 
-  /@astrojs/svelte@5.0.3(astro@4.0.9)(svelte@4.2.8)(typescript@5.3.3)(vite@5.0.10):
+  /@astrojs/svelte@5.0.3(astro@4.1.0)(svelte@4.2.8)(typescript@5.3.3)(vite@5.0.11):
     resolution: {integrity: sha512-6TUBRUxmsEczKPBT6oDUAfvzuFCmITuhZfKPT5ZtOOyj9XOVnEnj/Iobd3ajKUbpWNYX7qZVAd1KMkmJc1Nhsg==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       astro: ^4.0.0
       svelte: ^4.0.0 || ^5.0.0-next.1
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.2.8)(vite@5.0.10)
-      astro: 4.0.9(@types/node@20.10.6)(typescript@5.3.3)
+      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.2.8)(vite@5.0.11)
+      astro: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
       svelte: 4.2.8
       svelte2tsx: 0.6.27(svelte@4.2.8)(typescript@5.3.3)
     transitivePeerDependencies:
@@ -1693,7 +1694,7 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.16.0
 
-  /@preact/preset-vite@2.8.1(@babel/core@7.23.7)(preact@10.19.3)(vite@5.0.10):
+  /@preact/preset-vite@2.8.1(@babel/core@7.23.7)(preact@10.19.3)(vite@5.0.11):
     resolution: {integrity: sha512-a9KV4opdj17X2gOFuGup0aE+sXYABX/tJi/QDptOrleX4FlnoZgDWvz45tHOdVfrZX+3uvVsIYPHxRsTerkDNA==}
     peerDependencies:
       '@babel/core': 7.x
@@ -1702,7 +1703,7 @@ packages:
       '@babel/core': 7.23.7
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.23.7)
       '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.23.7)
-      '@prefresh/vite': 2.4.5(preact@10.19.3)(vite@5.0.10)
+      '@prefresh/vite': 2.4.5(preact@10.19.3)(vite@5.0.11)
       '@rollup/pluginutils': 4.2.1
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.23.7)
       debug: 4.3.4
@@ -1710,7 +1711,7 @@ packages:
       magic-string: 0.30.5
       node-html-parser: 6.1.12
       resolve: 1.22.8
-      vite: 5.0.10(@types/node@20.10.6)
+      vite: 5.0.11(@types/node@20.10.6)
     transitivePeerDependencies:
       - preact
       - supports-color
@@ -1745,7 +1746,7 @@ packages:
     resolution: {integrity: sha512-KtC/fZw+oqtwOLUFM9UtiitB0JsVX0zLKNyRTA332sqREqSALIIQQxdUCS1P3xR/jT1e2e8/5rwH6gdcMLEmsQ==}
     dev: false
 
-  /@prefresh/vite@2.4.5(preact@10.19.3)(vite@5.0.10):
+  /@prefresh/vite@2.4.5(preact@10.19.3)(vite@5.0.11):
     resolution: {integrity: sha512-iForDVJ2M8gQYnm5pHumvTEJjGGc7YNYC0GVKnHFL+GvFfKHfH9Rpq67nUAzNbjuLEpqEOUuQVQajMazWu2ZNQ==}
     peerDependencies:
       preact: ^10.4.0
@@ -1757,7 +1758,7 @@ packages:
       '@prefresh/utils': 1.2.0
       '@rollup/pluginutils': 4.2.1
       preact: 10.19.3
-      vite: 5.0.10(@types/node@20.10.6)
+      vite: 5.0.11(@types/node@20.10.6)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1770,92 +1771,92 @@ packages:
       picomatch: 2.3.1
     dev: false
 
-  /@rollup/rollup-android-arm-eabi@4.9.2:
-    resolution: {integrity: sha512-RKzxFxBHq9ysZ83fn8Iduv3A283K7zPPYuhL/z9CQuyFrjwpErJx0h4aeb/bnJ+q29GRLgJpY66ceQ/Wcsn3wA==}
+  /@rollup/rollup-android-arm-eabi@4.9.3:
+    resolution: {integrity: sha512-nvh9bB41vXEoKKvlWCGptpGt8EhrEwPQFDCY0VAto+R+qpSbaErPS3OjMZuXR8i/2UVw952Dtlnl2JFxH31Qvg==}
     cpu: [arm]
     os: [android]
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-android-arm64@4.9.2:
-    resolution: {integrity: sha512-yZ+MUbnwf3SHNWQKJyWh88ii2HbuHCFQnAYTeeO1Nb8SyEiWASEi5dQUygt3ClHWtA9My9RQAYkjvrsZ0WK8Xg==}
+  /@rollup/rollup-android-arm64@4.9.3:
+    resolution: {integrity: sha512-kffYCJ2RhDL1DlshLzYPyJtVeusHlA8Q1j6k6s4AEVKLq/3HfGa2ADDycLsmPo3OW83r4XtOPqRMbcFzFsEIzQ==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.9.2:
-    resolution: {integrity: sha512-vqJ/pAUh95FLc/G/3+xPqlSBgilPnauVf2EXOQCZzhZJCXDXt/5A8mH/OzU6iWhb3CNk5hPJrh8pqJUPldN5zw==}
+  /@rollup/rollup-darwin-arm64@4.9.3:
+    resolution: {integrity: sha512-Fo7DR6Q9/+ztTyMBZ79+WJtb8RWZonyCgkBCjV51rW5K/dizBzImTW6HLC0pzmHaAevwM0jW1GtB5LCFE81mSw==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-darwin-x64@4.9.2:
-    resolution: {integrity: sha512-otPHsN5LlvedOprd3SdfrRNhOahhVBwJpepVKUN58L0RnC29vOAej1vMEaVU6DadnpjivVsNTM5eNt0CcwTahw==}
+  /@rollup/rollup-darwin-x64@4.9.3:
+    resolution: {integrity: sha512-5HcxDF9fqHucIlTiw/gmMb3Qv23L8bLCg904I74Q2lpl4j/20z9ogaD3tWkeguRuz+/17cuS321PT3PAuyjQdg==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.9.2:
-    resolution: {integrity: sha512-ewG5yJSp+zYKBYQLbd1CUA7b1lSfIdo9zJShNTyc2ZP1rcPrqyZcNlsHgs7v1zhgfdS+kW0p5frc0aVqhZCiYQ==}
+  /@rollup/rollup-linux-arm-gnueabihf@4.9.3:
+    resolution: {integrity: sha512-cO6hKV+99D1V7uNJQn1chWaF9EGp7qV2N8sGH99q9Y62bsbN6Il55EwJppEWT+JiqDRg396vWCgwdHwje8itBQ==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.9.2:
-    resolution: {integrity: sha512-pL6QtV26W52aCWTG1IuFV3FMPL1m4wbsRG+qijIvgFO/VBsiXJjDPE/uiMdHBAO6YcpV4KvpKtd0v3WFbaxBtg==}
+  /@rollup/rollup-linux-arm64-gnu@4.9.3:
+    resolution: {integrity: sha512-xANyq6lVg6KMO8UUs0LjA4q7di3tPpDbzLPgVEU2/F1ngIZ54eli8Zdt3uUUTMXVbgTCafIO+JPeGMhu097i3w==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.9.2:
-    resolution: {integrity: sha512-On+cc5EpOaTwPSNetHXBuqylDW+765G/oqB9xGmWU3npEhCh8xu0xqHGUA+4xwZLqBbIZNcBlKSIYfkBm6ko7g==}
+  /@rollup/rollup-linux-arm64-musl@4.9.3:
+    resolution: {integrity: sha512-TZJUfRTugVFATQToCMD8DNV6jv/KpSwhE1lLq5kXiQbBX3Pqw6dRKtzNkh5wcp0n09reBBq/7CGDERRw9KmE+g==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-riscv64-gnu@4.9.2:
-    resolution: {integrity: sha512-Wnx/IVMSZ31D/cO9HSsU46FjrPWHqtdF8+0eyZ1zIB5a6hXaZXghUKpRrC4D5DcRTZOjml2oBhXoqfGYyXKipw==}
+  /@rollup/rollup-linux-riscv64-gnu@4.9.3:
+    resolution: {integrity: sha512-4/QVaRyaB5tkEAGfjVvWrmWdPF6F2NoaoO5uEP7N0AyeBw7l8SeCWWKAGrbx/00PUdHrJVURJiYikazslSKttQ==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.9.2:
-    resolution: {integrity: sha512-ym5x1cj4mUAMBummxxRkI4pG5Vht1QMsJexwGP8547TZ0sox9fCLDHw9KCH9c1FO5d9GopvkaJsBIOkTKxksdw==}
+  /@rollup/rollup-linux-x64-gnu@4.9.3:
+    resolution: {integrity: sha512-koLC6D3pj1YLZSkTy/jsk3HOadp7q2h6VQl/lPX854twOmmLNekHB6yuS+MkWcKdGGdW1JPuPBv/ZYhr5Yhtdg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.9.2:
-    resolution: {integrity: sha512-m0hYELHGXdYx64D6IDDg/1vOJEaiV8f1G/iO+tejvRCJNSwK4jJ15e38JQy5Q6dGkn1M/9KcyEOwqmlZ2kqaZg==}
+  /@rollup/rollup-linux-x64-musl@4.9.3:
+    resolution: {integrity: sha512-0OAkQ4HBp+JO2ip2Lgt/ShlrveOMzyhwt2D0KvqH28jFPqfZco28KSq76zymZwmU+F6GRojdxtQMJiNSXKNzeA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.9.2:
-    resolution: {integrity: sha512-x1CWburlbN5JjG+juenuNa4KdedBdXLjZMp56nHFSHTOsb/MI2DYiGzLtRGHNMyydPGffGId+VgjOMrcltOksA==}
+  /@rollup/rollup-win32-arm64-msvc@4.9.3:
+    resolution: {integrity: sha512-z5uvoMvdRWggigOnsb9OOCLERHV0ykRZoRB5O+URPZC9zM3pkoMg5fN4NKu2oHqgkzZtfx9u4njqqlYEzM1v9A==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.9.2:
-    resolution: {integrity: sha512-VVzCB5yXR1QlfsH1Xw1zdzQ4Pxuzv+CPr5qpElpKhVxlxD3CRdfubAG9mJROl6/dmj5gVYDDWk8sC+j9BI9/kQ==}
+  /@rollup/rollup-win32-ia32-msvc@4.9.3:
+    resolution: {integrity: sha512-wxomCHjBVKws+O4N1WLnniKCXu7vkLtdq9Fl9CN/EbwEldojvUrkoHE/fBLZzC7IT/x12Ut6d6cRs4dFvqJkMg==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-win32-x64-msvc@4.9.2:
-    resolution: {integrity: sha512-SYRedJi+mweatroB+6TTnJYLts0L0bosg531xnQWtklOI6dezEagx4Q0qDyvRdK+qgdA3YZpjjGuPFtxBmddBA==}
+  /@rollup/rollup-win32-x64-msvc@4.9.3:
+    resolution: {integrity: sha512-1Qf/qk/iEtx0aOi+AQQt5PBoW0mFngsm7bPuxHClC/hWh2hHBktR6ktSfUg5b5rC9v8hTwNmHE7lBWXkgqluUQ==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -1907,7 +1908,7 @@ packages:
       utility-types: 3.10.0
     dev: false
 
-  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.10):
+  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.11):
     resolution: {integrity: sha512-gjr9ZFg1BSlIpfZ4PRewigrvYmHWbDrq2uvvPB1AmTWKuM+dI1JXQSUu2pIrYLb/QncyiIGkFDFKTwJ0XqQZZg==}
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
@@ -1915,30 +1916,30 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.2.8)(vite@5.0.10)
+      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.2.8)(vite@5.0.11)
       debug: 4.3.4
       svelte: 4.2.8
-      vite: 5.0.10(@types/node@20.10.6)
+      vite: 5.0.11(@types/node@20.10.6)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.2.8)(vite@5.0.10):
+  /@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.2.8)(vite@5.0.11):
     resolution: {integrity: sha512-CGURX6Ps+TkOovK6xV+Y2rn8JKa8ZPUHPZ/NKgCxAmgBrXReavzFl8aOSCj3kQ1xqT7yGJj53hjcV/gqwDAaWA==}
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.10)
+      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.11)
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.5
       svelte: 4.2.8
       svelte-hmr: 0.15.3(svelte@4.2.8)
-      vite: 5.0.10(@types/node@20.10.6)
-      vitefu: 0.2.5(vite@5.0.10)
+      vite: 5.0.11(@types/node@20.10.6)
+      vitefu: 0.2.5(vite@5.0.11)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2066,7 +2067,7 @@ packages:
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  /@vitejs/plugin-react@4.2.1(vite@5.0.10):
+  /@vitejs/plugin-react@4.2.1(vite@5.0.11):
     resolution: {integrity: sha512-oojO9IDc4nCUUi8qIR11KoQm0XFFLIwsRBwHRR4d/88IWghn1y6ckz/bJ8GHDCsYEJee8mDzqtJxh15/cisJNQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -2077,7 +2078,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.0.10(@types/node@20.10.6)
+      vite: 5.0.11(@types/node@20.10.6)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2087,7 +2088,7 @@ packages:
     dependencies:
       '@vitest/spy': 1.0.4
       '@vitest/utils': 1.0.4
-      chai: 4.3.10
+      chai: 4.4.0
     dev: true
 
   /@vitest/runner@1.0.4:
@@ -2196,7 +2197,6 @@ packages:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
     dependencies:
       dequal: 2.0.3
-    dev: false
 
   /array-buffer-byte-length@1.0.0:
     resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
@@ -2250,12 +2250,12 @@ packages:
     hasBin: true
     dev: false
 
-  /astro@4.0.9(@types/node@20.10.6)(typescript@5.3.3):
-    resolution: {integrity: sha512-xQHapUGqdHQuaBDCYZxyVh5rvpgIUuulsEITl7bOQ6rRXwbQtoGc5gQ95dGV830PEpvyAGVhQ9pA8PIwfCMpeg==}
+  /astro@4.1.0(@types/node@20.10.6)(typescript@5.3.3):
+    resolution: {integrity: sha512-xbLWqvMn2JFyv7FpzHiXFn17bRS0P/b4cdEPXMMZOpBI9V8ZC33o6Xs+c59/pYSZpYiNd1HTg778XT5MhcpyKw==}
     engines: {node: '>=18.14.1', npm: '>=6.14.0'}
     hasBin: true
     dependencies:
-      '@astrojs/compiler': 2.3.4
+      '@astrojs/compiler': 2.4.0
       '@astrojs/internal-helpers': 0.2.1
       '@astrojs/markdown-remark': 4.0.1
       '@astrojs/telemetry': 3.0.4
@@ -2267,6 +2267,8 @@ packages:
       '@babel/types': 7.23.6
       '@types/babel__core': 7.20.5
       acorn: 8.11.3
+      aria-query: 5.3.0
+      axobject-query: 4.0.0
       boxen: 7.1.1
       chokidar: 3.5.3
       ci-info: 4.0.0
@@ -2308,11 +2310,11 @@ packages:
       shikiji: 0.6.13
       string-width: 7.0.0
       strip-ansi: 7.1.0
-      tsconfck: 3.0.0(typescript@5.3.3)
+      tsconfck: 3.0.1(typescript@5.3.3)
       unist-util-visit: 5.0.0
       vfile: 6.0.1
-      vite: 5.0.10(@types/node@20.10.6)
-      vitefu: 0.2.5(vite@5.0.10)
+      vite: 5.0.11(@types/node@20.10.6)
+      vitefu: 0.2.5(vite@5.0.11)
       which-pm: 2.1.1
       yargs-parser: 21.1.1
       zod: 3.22.4
@@ -2340,8 +2342,13 @@ packages:
       dequal: 2.0.3
     dev: false
 
-  /babel-plugin-jsx-dom-expressions@0.37.9(@babel/core@7.23.7):
-    resolution: {integrity: sha512-6w+zs2i14fVanj4e1hXCU5cp+x0U0LJ5jScknpMZZUteHhwFRGJflHMVJ+xAcW7ku41FYjr7DgtK9mnc2SXlJg==}
+  /axobject-query@4.0.0:
+    resolution: {integrity: sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==}
+    dependencies:
+      dequal: 2.0.3
+
+  /babel-plugin-jsx-dom-expressions@0.37.11(@babel/core@7.23.7):
+    resolution: {integrity: sha512-0NaWy4sFsE0AWlucvL/myEiZ851BgjeLwhtctOFmyVCK6fPXqQHQUBB5SrrrmvOiw/BZCmMe8dOy7JL3FSyTtQ==}
     peerDependencies:
       '@babel/core': ^7.20.12
     dependencies:
@@ -2370,13 +2377,13 @@ packages:
       '@babel/core': 7.23.7
     dev: false
 
-  /babel-preset-solid@1.8.6(@babel/core@7.23.7):
-    resolution: {integrity: sha512-Ened42CHjU4EFkvNeS042/3Pm21yvMWn8p4G4ddzQTlKaMwSGGD1VciA/e7EshBVHJCcBj9vHiUd/r3A4qLPZA==}
+  /babel-preset-solid@1.8.8(@babel/core@7.23.7):
+    resolution: {integrity: sha512-m+sFxzriUgMiyUPz/oWxU+N6PwY2bVsZVlc4Jxx+5XhDt5lGE/meg+ZL/kLgSAZ75YuU9AJZr444Un1bO0vhJQ==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.23.7
-      babel-plugin-jsx-dom-expressions: 0.37.9(@babel/core@7.23.7)
+      babel-plugin-jsx-dom-expressions: 0.37.11(@babel/core@7.23.7)
     dev: false
 
   /bail@2.0.2:
@@ -2439,8 +2446,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001572
-      electron-to-chromium: 1.4.616
+      caniuse-lite: 1.0.30001574
+      electron-to-chromium: 1.4.622
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.22.2)
 
@@ -2486,14 +2493,14 @@ packages:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
     engines: {node: '>=14.16'}
 
-  /caniuse-lite@1.0.30001572:
-    resolution: {integrity: sha512-1Pbh5FLmn5y4+QhNyJE9j3/7dK44dGB83/ZMjv/qJk86TvDbjk0LosiZo0i0WB0Vx607qMX9jYrn1VLHCkN4rw==}
+  /caniuse-lite@1.0.30001574:
+    resolution: {integrity: sha512-BtYEK4r/iHt/txm81KBudCUcTy7t+s9emrIaHqjYurQ10x71zJ5VQ9x1dYPcz/b+pKSp4y/v1xSI67A+LzpNyg==}
 
   /ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  /chai@4.3.10:
-    resolution: {integrity: sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==}
+  /chai@4.4.0:
+    resolution: {integrity: sha512-x9cHNq1uvkCdU+5xTkNh5WtgD4e4yDFCsp9jVc7N7qVeKeftv3gO/ZrviX5d+3ZfxdYnZXZYujjRInu1RogU6A==}
     engines: {node: '>=4'}
     dependencies:
       assertion-error: 1.1.0
@@ -2958,8 +2965,8 @@ packages:
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  /electron-to-chromium@1.4.616:
-    resolution: {integrity: sha512-1n7zWYh8eS0L9Uy+GskE0lkBUNK83cXTVJI0pU3mGprFsbfSdAc15VTFbo+A+Bq4pwstmL30AVcEU3Fo463lNg==}
+  /electron-to-chromium@1.4.622:
+    resolution: {integrity: sha512-GZ47DEy0Gm2Z8RVG092CkFvX7SdotG57c4YZOe8W8qD4rOmk3plgeNmiLVRHP/Liqj1wRiY3uUUod9vb9hnxZA==}
 
   /emoji-regex@10.3.0:
     resolution: {integrity: sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==}
@@ -3603,8 +3610,8 @@ packages:
     hasBin: true
     dev: false
 
-  /hono@3.11.12:
-    resolution: {integrity: sha512-TrxH75bc0m2UbvrhaXkoo32A9OhkJtvICAYgYWtxqLDOxBjRqSikyp4K7HTbnWkPeg9Z+2Q3nv0dN4o8kL6yLg==}
+  /hono@3.12.0:
+    resolution: {integrity: sha512-UPEtZuLY7Wo7g0mqKWSOjLFdT8t7wJ60IYEcxKl3AQNU4u+R2QqU2fJMPmSu24C+/ag20Z8mOTQOErZzK4DMvA==}
     engines: {node: '>=16.0.0'}
 
   /hosted-git-info@2.8.9:
@@ -5019,8 +5026,8 @@ packages:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: false
 
-  /postcss@8.4.32:
-    resolution: {integrity: sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==}
+  /postcss@8.4.33:
+    resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.7
@@ -5034,6 +5041,14 @@ packages:
     dependencies:
       preact: 10.19.3
       pretty-format: 3.8.0
+    dev: false
+
+  /preact-ssr-prepass@1.2.1(preact@10.19.3):
+    resolution: {integrity: sha512-bLgbUfy8nL+PZghAPpyk9MF+cmXjdwEnxYPaJBmwbzFQqzIz8dQVBqjwB60RqZ9So/vIf6BRfHCiwFGuMCyfbQ==}
+    peerDependencies:
+      preact: '>=10 || ^10.0.0-beta.0 || ^10.0.0-alpha.0'
+    dependencies:
+      preact: 10.19.3
     dev: false
 
   /preact@10.19.3:
@@ -5265,13 +5280,13 @@ packages:
       unified: 11.0.4
       vfile: 6.0.1
 
-  /remark-smartypants@2.0.0:
-    resolution: {integrity: sha512-Rc0VDmr/yhnMQIz8n2ACYXlfw/P/XZev884QU1I5u+5DgJls32o97Vc1RbK3pfumLsJomS2yy8eT4Fxj/2MDVA==}
+  /remark-smartypants@2.1.0:
+    resolution: {integrity: sha512-qoF6Vz3BjU2tP6OfZqHOvCU0ACmu/6jhGaINSQRI9mM7wCxNQTKB3JUAN4SVoN2ybElEDTxBIABRep7e569iJw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       retext: 8.1.0
       retext-smartypants: 5.2.0
-      unist-util-visit: 4.1.2
+      unist-util-visit: 5.0.0
 
   /remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
@@ -5349,24 +5364,26 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  /rollup@4.9.2:
-    resolution: {integrity: sha512-66RB8OtFKUTozmVEh3qyNfH+b+z2RXBVloqO2KCC/pjFaGaHtxP9fVfOQKPSGXg2mElmjmxjW/fZ7iKrEpMH5Q==}
+  /rollup@4.9.3:
+    resolution: {integrity: sha512-JnchF0ZGFiqGpAPjg3e89j656Ne4tTtCY1VZc1AxtoQcRIxjTu9jyYHBAtkDXE+X681n4un/nX9SU52AroSRzg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+    dependencies:
+      '@types/estree': 1.0.5
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.9.2
-      '@rollup/rollup-android-arm64': 4.9.2
-      '@rollup/rollup-darwin-arm64': 4.9.2
-      '@rollup/rollup-darwin-x64': 4.9.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.9.2
-      '@rollup/rollup-linux-arm64-gnu': 4.9.2
-      '@rollup/rollup-linux-arm64-musl': 4.9.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.9.2
-      '@rollup/rollup-linux-x64-gnu': 4.9.2
-      '@rollup/rollup-linux-x64-musl': 4.9.2
-      '@rollup/rollup-win32-arm64-msvc': 4.9.2
-      '@rollup/rollup-win32-ia32-msvc': 4.9.2
-      '@rollup/rollup-win32-x64-msvc': 4.9.2
+      '@rollup/rollup-android-arm-eabi': 4.9.3
+      '@rollup/rollup-android-arm64': 4.9.3
+      '@rollup/rollup-darwin-arm64': 4.9.3
+      '@rollup/rollup-darwin-x64': 4.9.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.9.3
+      '@rollup/rollup-linux-arm64-gnu': 4.9.3
+      '@rollup/rollup-linux-arm64-musl': 4.9.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.9.3
+      '@rollup/rollup-linux-x64-gnu': 4.9.3
+      '@rollup/rollup-linux-x64-musl': 4.9.3
+      '@rollup/rollup-win32-arm64-msvc': 4.9.3
+      '@rollup/rollup-win32-ia32-msvc': 4.9.3
+      '@rollup/rollup-win32-x64-msvc': 4.9.3
       fsevents: 2.3.3
 
   /run-parallel@1.2.0:
@@ -5450,8 +5467,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /seroval@0.15.1:
-    resolution: {integrity: sha512-OPVtf0qmeC7RW+ScVX+7aOS+xoIM7pWcZ0jOWg2aTZigCydgRB04adfteBRbecZnnrO1WuGQ+C3tLeBBzX2zSQ==}
+  /seroval@1.0.2:
+    resolution: {integrity: sha512-buswWxRzf65ZGUk8MAf3qVtBJHbe5gq6hZyPeqlJCKEIl/tEhUZze0YJg7vB7tFRGgPeneRaP083OB/vDiYLvA==}
     engines: {node: '>=10'}
     dev: false
 
@@ -5590,14 +5607,14 @@ packages:
       yargs: 15.4.1
     dev: true
 
-  /solid-js@1.8.7:
-    resolution: {integrity: sha512-9dzrSVieh2zj3SnJ02II6xZkonR6c+j/91b7XZUNcC6xSaldlqjjGh98F1fk5cRJ8ZTkzqF5fPIWDxEOs6QZXA==}
+  /solid-js@1.8.8:
+    resolution: {integrity: sha512-9CtL5xWTYX1WWjQKqht3Tl0AJzgz4YWVQk8hoscO9TzRCgzlpAauEOexXa6bPG30W+fWLnFVE7XUiAzQFNeUKw==}
     dependencies:
       csstype: 3.1.3
-      seroval: 0.15.1
+      seroval: 1.0.2
     dev: false
 
-  /solid-refresh@0.5.3(solid-js@1.8.7):
+  /solid-refresh@0.5.3(solid-js@1.8.8):
     resolution: {integrity: sha512-Otg5it5sjOdZbQZJnvo99TEBAr6J7PQ5AubZLNU6szZzg3RQQ5MX04oteBIIGDs0y2Qv8aXKm9e44V8z+UnFdw==}
     peerDependencies:
       solid-js: ^1.3
@@ -5605,7 +5622,7 @@ packages:
       '@babel/generator': 7.23.6
       '@babel/helper-module-imports': 7.22.15
       '@babel/types': 7.23.6
-      solid-js: 1.8.7
+      solid-js: 1.8.8
     dev: false
 
   /source-map-js@1.0.2:
@@ -5925,8 +5942,8 @@ packages:
   /trough@2.1.0:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
 
-  /tsconfck@3.0.0(typescript@5.3.3):
-    resolution: {integrity: sha512-w3wnsIrJNi7avf4Zb0VjOoodoO0woEqGgZGQm+LHH9przdUI+XDKsWAXwxHA1DaRTjeuZNcregSzr7RaA8zG9A==}
+  /tsconfck@3.0.1(typescript@5.3.3):
+    resolution: {integrity: sha512-7ppiBlF3UEddCLeI1JRx5m2Ryq+xk4JrZuq4EuYXykipebaq1dV0Fhgr1hb7CkmHt32QSgOZlcqVLEtHBG4/mg==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:
@@ -6222,7 +6239,7 @@ packages:
       debug: 4.3.4
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 5.0.10(@types/node@20.10.6)
+      vite: 5.0.11(@types/node@20.10.6)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6234,7 +6251,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-solid@2.8.0(solid-js@1.8.7)(vite@5.0.10):
+  /vite-plugin-solid@2.8.0(solid-js@1.8.8)(vite@5.0.11):
     resolution: {integrity: sha512-n5FAm7ZmTl94VWUoiJCgG7bouF2NlC9CA1wY/qbVnkFbYDWk++bFWyNoU48aLJ+lMtzNeYzJypJXOHzFKxL9xA==}
     peerDependencies:
       solid-js: ^1.7.2
@@ -6243,18 +6260,18 @@ packages:
       '@babel/core': 7.23.7
       '@babel/preset-typescript': 7.23.3(@babel/core@7.23.7)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.8.6(@babel/core@7.23.7)
+      babel-preset-solid: 1.8.8(@babel/core@7.23.7)
       merge-anything: 5.1.7
-      solid-js: 1.8.7
-      solid-refresh: 0.5.3(solid-js@1.8.7)
-      vite: 5.0.10(@types/node@20.10.6)
-      vitefu: 0.2.5(vite@5.0.10)
+      solid-js: 1.8.8
+      solid-refresh: 0.5.3(solid-js@1.8.8)
+      vite: 5.0.11(@types/node@20.10.6)
+      vitefu: 0.2.5(vite@5.0.11)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /vite@5.0.10(@types/node@20.10.6):
-    resolution: {integrity: sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==}
+  /vite@5.0.11(@types/node@20.10.6):
+    resolution: {integrity: sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -6283,12 +6300,12 @@ packages:
     dependencies:
       '@types/node': 20.10.6
       esbuild: 0.19.11
-      postcss: 8.4.32
-      rollup: 4.9.2
+      postcss: 8.4.33
+      rollup: 4.9.3
     optionalDependencies:
       fsevents: 2.3.3
 
-  /vitefu@0.2.5(vite@5.0.10):
+  /vitefu@0.2.5(vite@5.0.11):
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0
@@ -6296,7 +6313,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 5.0.10(@types/node@20.10.6)
+      vite: 5.0.11(@types/node@20.10.6)
 
   /vitest@1.0.4:
     resolution: {integrity: sha512-s1GQHp/UOeWEo4+aXDOeFBJwFzL6mjycbQwwKWX2QcYfh/7tIerS59hWQ20mxzupTJluA2SdwiBuWwQHH67ckg==}
@@ -6330,7 +6347,7 @@ packages:
       '@vitest/utils': 1.0.4
       acorn-walk: 8.3.1
       cac: 6.7.14
-      chai: 4.3.10
+      chai: 4.4.0
       debug: 4.3.4
       execa: 8.0.1
       local-pkg: 0.5.0
@@ -6341,7 +6358,7 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.1
       tinypool: 0.8.1
-      vite: 5.0.10(@types/node@20.10.6)
+      vite: 5.0.11(@types/node@20.10.6)
       vite-node: 1.0.4
       why-is-node-running: 2.2.2
     transitivePeerDependencies:


### PR DESCRIPTION
# Changes
- Since Astro 4.1, API endpoints now require a trailing slash if configured by the user.
- https://github.com/withastro/astro/pull/9597
- If `trailingSlash` is configured, the previous version of typed-api will no longer work.
- The next version of typed-api will no longer work on astro 4.0 or lower.

# Tests
- Existing tests should pass. (base and trailingSlash are already tested)

# Docs
- peerDependencies range will be updated to require astro 4.1+.
- Does not affect usage.