### PR TITLE
qol(typed api): type error when the API route is exported as lowercase

### DIFF
--- a/.changeset/funny-news-retire.md
+++ b/.changeset/funny-news-retire.md
@@ -1,0 +1,5 @@
+---
+"astro-typed-api": patch
+---
+
+Adds a helpful typescript error for when an export is not uppercase.

--- a/packages/typed-api/types.ts
+++ b/packages/typed-api/types.ts
@@ -16,7 +16,12 @@ type Route<Endpoint extends string, EndpointModule> =
     EndpointToObject<Endpoint, ModuleProxy<EndpointModule, never>>
 
 type ModuleProxy<EndpointModule, Params extends string> = {
-    [Method in keyof EndpointModule]: MethodProxy<EndpointModule[Method], Params, Method extends string ? Method : never>
+    [Method in keyof EndpointModule]:
+        Method extends string
+            ? Method extends Uppercase<Method>
+                ? MethodProxy<EndpointModule[Method], Params, Method extends string ? Method : never>
+            : TypedAPITypeError<"The method of an API Route must be exported as uppercase.">
+        : TypedAPITypeError<"The method of an API Route must be exported as uppercase.">
 }
 
 type MethodProxy<MethodExport, Params extends string, Method extends string> =


### PR DESCRIPTION
# Changes
<img width="692" alt="image" src="https://github.com/lilnasy/gratelets/assets/69170106/32b0cd06-ef94-4c0f-89a7-af9bd4fb661f">

# Testing
Probably should introduce `tsc` and `astro check` but nothing yet.

# Docs
Does not affect usage.