### PR TITLE
New Integration: Server-Only Modules

### DIFF
--- a/.changeset/light-goats-bathe.md
+++ b/.changeset/light-goats-bathe.md
@@ -1,0 +1,5 @@
+---
+"astro-server-only-modules": major
+---
+
+Initial release

--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ A collection of purpose-built, small, third-party integrations for Astro.
 - **astro-hono** - run your app on a Hono-powered server. [README](https://github.com/lilnasy/gratelets/tree/main/packages/hono) | [NPM](https://www.npmjs.com/package/astro-hono)
 - **astro-prerender-patterns** - control rendering modes for all pages and endpoints right from the configuration. [README](https://github.com/lilnasy/gratelets/tree/main/packages/prerender-patterns) | [NPM](https://www.npmjs.com/package/astro-prerender-patterns)
 - **astro-scope** - get the hash used by the astro compiler to scope css rules. [README](https://github.com/lilnasy/gratelets/tree/main/packages/scope) | [NPM](https://www.npmjs.com/package/astro-scope)
+- **astro-server-only-modules** - prevent certain modules from being imported into client-side code. [README](https://github.com/lilnasy/gratelets/tree/main/packages/server-only-modules) | [NPM](https://www.npmjs.com/package/astro-server-only-modules)
 - **astro-stylex** - CSS-in-Zero-JS using [StyleX](https://stylexjs.com/). [README](https://github.com/lilnasy/gratelets/tree/main/packages/stylex) | [NPM](https://www.npmjs.com/package/astro-stylex)
 - **astro-typed-api** - type-safe API routes. [README](https://github.com/lilnasy/gratelets/tree/main/packages/typed-api) | [NPM](https://www.npmjs.com/package/astro-typed-api)

--- a/packages/server-only-modules/README.md
+++ b/packages/server-only-modules/README.md
@@ -1,0 +1,56 @@
+# astro-server-only-modules 🗣️
+
+This **[Astro integration][astro-integration]** lets you explicitly mark modules whose code should never be sent to the browser.
+
+- <strong>[Why astro-server-only-modules?](#why-astro-server-only-modules)</strong>
+- <strong>[Installation](#installation)</strong>
+- <strong>[Usage](#usage)</strong>
+- <strong>[Troubleshooting](#troubleshooting)</strong>
+- <strong>[Contributing](#contributing)</strong>
+- <strong>[Changelog](#changelog)</strong>
+
+## Why astro-server-only-modules?
+
+
+## Installation
+
+### Manual Install
+
+First, install the `astro-server-only-modules` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
+
+```sh
+npm install astro-server-only-modules
+```
+
+Then, apply this integration to your `astro.config.*` file using the `integrations` property:
+
+```diff lang="js" "mdx()"
+  // astro.config.mjs
+  import { defineConfig } from 'astro/config';
+  import mdx from '@astrojs/mdx';
++ import serverOnlyModules from 'astro-server-only-modules';
+
+  export default defineConfig({
+    // ...
++   integrations: [serverOnlyModules()],
+    //             ^^^^^^^^^^^^^^^^^
+  });
+```
+
+## Usage
+
+Once the integration is installed and added to the configuration file, rename modules that should only be used within the server to end with `.server.ts`.
+
+## Troubleshooting
+
+For help, check out the `Discussions` tab on the [GitHub repo](https://github.com/lilnasy/gratelets/discussions).
+
+## Contributing
+
+This package is maintained by [lilnasy](https://github.com/lilnasy) independently from Astro. The integration code is located at [packages/server-only-modules/integration.ts](https://github.com/lilnasy/gratelets/blob/main/packages/server-only-modules/integration.ts). You're welcome to contribute by submitting an issue or opening a PR!
+
+## Changelog
+
+See [CHANGELOG.md](https://github.com/lilnasy/gratelets/blob/main/packages/server-only-modules/CHANGELOG.md) for a history of changes to this integration.
+
+[astro-integration]: https://docs.astro.build/en/guides/integrations-guide/

--- a/packages/server-only-modules/README.md
+++ b/packages/server-only-modules/README.md
@@ -1,6 +1,6 @@
 # astro-server-only-modules 🗣️
 
-This **[Astro integration][astro-integration]** lets you explicitly mark modules whose code should never be sent to the browser.
+This **[Astro integration][astro-integration]** allows you to make sure you never leak security-sensitive code to the browser.
 
 - <strong>[Why astro-server-only-modules?](#why-astro-server-only-modules)</strong>
 - <strong>[Installation](#installation)</strong>
@@ -11,6 +11,9 @@ This **[Astro integration][astro-integration]** lets you explicitly mark modules
 
 ## Why astro-server-only-modules?
 
+In a large codebase, it can be difficult to keep track of how code is being shared and where. This becomes a security risk when you have critical information that should only be available to the server. There are parts of your infrastructure that the browser (and therefore, a malicious user) does not need to be privy to.
+
+This integration allows you to delineate the context of your code to only include it in the server app. If one of the modules ending with `.server.ts` extension accidentally gets imported by client-side, directly or indirectly, the build will fail.
 
 ## Installation
 
@@ -24,10 +27,9 @@ npm install astro-server-only-modules
 
 Then, apply this integration to your `astro.config.*` file using the `integrations` property:
 
-```diff lang="js" "mdx()"
+```diff lang="js" "serverOnlyModules()"
   // astro.config.mjs
   import { defineConfig } from 'astro/config';
-  import mdx from '@astrojs/mdx';
 + import serverOnlyModules from 'astro-server-only-modules';
 
   export default defineConfig({
@@ -39,7 +41,7 @@ Then, apply this integration to your `astro.config.*` file using the `integratio
 
 ## Usage
 
-Once the integration is installed and added to the configuration file, rename modules that should only be used within the server to end with `.server.ts`.
+Once the integration is installed and added to the configuration file, rename modules that should only be used within the server to end with `.server.ts`. If one of these modules accidentally gets imported by client-side, directly or indirectly, the build will fail.
 
 ## Troubleshooting
 

--- a/packages/server-only-modules/README.md
+++ b/packages/server-only-modules/README.md
@@ -1,4 +1,4 @@
-# astro-server-only-modules 🗣️
+# astro-server-only-modules 🔐
 
 This **[Astro integration][astro-integration]** allows you to make sure you never leak security-sensitive code to the browser.
 

--- a/packages/server-only-modules/integration.ts
+++ b/packages/server-only-modules/integration.ts
@@ -2,6 +2,9 @@ import type { AstroIntegration } from "astro"
 
 interface Options {}
 
+/**
+ * Prevents modules with the extension `.server.ts` from being imported into client-side code.
+ */
 export default function (_?: Options): AstroIntegration {
     let buildingFor: "server" | "client" | undefined = undefined
     return {
@@ -11,8 +14,19 @@ export default function (_?: Options): AstroIntegration {
                 updateConfig({ vite: { plugins: [{
                     name: "server-only-modules/vite",
                     load(specifier) {
-                        if (specifier.endsWith(".server.ts") && buildingFor === "client") {
-                            throw new Error(`Cannot import ${specifier} in the ${buildingFor} build.`)
+                        if (buildingFor === "client") {
+                            if (
+                                specifier.endsWith(".server.ts") ||
+                                specifier.endsWith(".server.mts") ||
+                                specifier.endsWith(".server.cts") ||
+                                specifier.endsWith(".server.tsx") ||
+                                specifier.endsWith(".server.js") ||
+                                specifier.endsWith(".server.mjs") ||
+                                specifier.endsWith(".server.cjs") ||
+                                specifier.endsWith(".server.jsx")
+                            ) {
+                                throw new ServerOnlyModule
+                            }
                         }
                     },
                 }] } })
@@ -21,5 +35,12 @@ export default function (_?: Options): AstroIntegration {
                 buildingFor = target
             }
         }
+    }
+}
+
+class ServerOnlyModule extends Error {
+    name = "ServerOnlyModule"
+    constructor() {
+        super(`Cannot import a server-only module in the client build.`)
     }
 }

--- a/packages/server-only-modules/integration.ts
+++ b/packages/server-only-modules/integration.ts
@@ -1,0 +1,25 @@
+import type { AstroIntegration } from "astro"
+
+interface Options {}
+
+export default function (_?: Options): AstroIntegration {
+    let buildingFor: "server" | "client" | undefined = undefined
+    return {
+        name: "server-only-modules",
+        hooks: {
+            "astro:config:setup" ({ updateConfig }) {
+                updateConfig({ vite: { plugins: [{
+                    name: "server-only-modules/vite",
+                    load(specifier) {
+                        if (specifier.endsWith(".server.ts") && buildingFor === "client") {
+                            throw new Error(`Cannot import ${specifier} in the ${buildingFor} build.`)
+                        }
+                    },
+                }] } })
+            },
+            "astro:build:setup" ({ target }) {
+                buildingFor = target
+            }
+        }
+    }
+}

--- a/packages/server-only-modules/package.json
+++ b/packages/server-only-modules/package.json
@@ -1,7 +1,7 @@
 {
     "name": "astro-server-only-modules",
     "version": "0.0.0",
-    "description": "",
+    "description": "Make sure you never leak security-sensitive code to the browser.",
     "author": "Arsh",
     "license": "Public Domain",
     "keywords": [

--- a/packages/server-only-modules/package.json
+++ b/packages/server-only-modules/package.json
@@ -1,0 +1,31 @@
+{
+    "name": "astro-server-only-modules",
+    "version": "0.0.0",
+    "description": "",
+    "author": "Arsh",
+    "license": "Public Domain",
+    "keywords": [
+        "withastro",
+        "astro-component"
+    ],
+    "homepage": "https://github.com/lilnasy/gratelets/tree/main/packages/server-only-modules",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/lilnasy/gratelets",
+        "directory": "packages/server-only-modules"
+    },
+    "files": [
+        "integration.ts"
+    ],
+    "exports": {
+        ".": "./integration.ts"
+    },
+    "scripts": {
+        "test": "pnpm -w test server-only-modules.test.ts"
+    },
+    "type": "module",
+    "devDependencies": {
+        "@types/node": "20",
+        "astro": "4"
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,15 @@ importers:
         specifier: '20'
         version: 20.10.6
 
+  packages/server-only-modules:
+    devDependencies:
+      '@types/node':
+        specifier: '20'
+        version: 20.10.6
+      astro:
+        specifier: '4'
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
+
   packages/stylex:
     dependencies:
       '@babel/core':
@@ -421,6 +430,15 @@ importers:
       astro-scope:
         specifier: workspace:*
         version: link:../../../packages/scope
+
+  tests/fixtures/server-only-modules:
+    dependencies:
+      astro:
+        specifier: '4'
+        version: 4.1.0(@types/node@20.10.6)(typescript@5.3.3)
+      astro-server-only-modules:
+        specifier: workspace:*
+        version: link:../../../packages/server-only-modules
 
   tests/fixtures/stylex:
     dependencies:

--- a/tests/fixtures/adds-to-head/src/pages/index.astro
+++ b/tests/fixtures/adds-to-head/src/pages/index.astro
@@ -3,6 +3,8 @@ import { getEntryBySlug } from "astro:content"
 import IndirectRenderer from "../components/IndirectRenderer.astro"
 
 const entry = await getEntryBySlug("blog", "promo/launch-week-component")
+entry.Component;
+entry.addsToHead = true;
 ---
 <html>
 	<head>

--- a/tests/fixtures/server-only-modules/astro.config.ts
+++ b/tests/fixtures/server-only-modules/astro.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "astro/config"
+import serverOnlyModules from "astro-server-only-modules"
+
+// https://astro.build/config
+export default defineConfig({
+    integrations: process.env.INCLUDE === "true" ? [serverOnlyModules()] : [],
+});

--- a/tests/fixtures/server-only-modules/package.json
+++ b/tests/fixtures/server-only-modules/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "@test/server-only-modules",
+    "private": true,
+    "dependencies": {
+        "astro": "4",
+        "astro-server-only-modules": "workspace:*"
+    }
+}

--- a/tests/fixtures/server-only-modules/src/pages/index.astro
+++ b/tests/fixtures/server-only-modules/src/pages/index.astro
@@ -1,0 +1,16 @@
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={Astro.generator} />
+		<title>Astro</title>
+		<script>
+			import { X } from "../x.server"
+			console.log(X)
+		</script>
+	</head>
+	<body>
+		<h1>Astro</h1>
+	</body>
+</html>

--- a/tests/fixtures/server-only-modules/src/x.server.ts
+++ b/tests/fixtures/server-only-modules/src/x.server.ts
@@ -1,0 +1,1 @@
+export const X = "X"

--- a/tests/server-only-modules.test.ts
+++ b/tests/server-only-modules.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest"
+import { build } from "./utils.ts"
+
+describe("astro-server-only-modules", () => {
+    test("Build succeeds without the integration.", async () => {
+        process.env.INCLUDE = "false"
+        await build("./fixtures/server-only-modules")
+    })
+    test("Build fails with the integration.", async () => {
+        process.env.INCLUDE = "true"
+        try {
+            await build("./fixtures/server-only-modules")
+            expect.unreachable()
+        } catch {}
+    })
+})


### PR DESCRIPTION
# Changes
 - Adds a new integration that allows you to make sure that certain modules are never sent to the browser.
 - Inclusion of any file ending with `.server.ts` in the client bundle will make the build fail.
 
 # Testing
 - Added a fixture
 
 # Docs
 - Added a readme