### PR TITLE
chore: update action runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     uses: ./.github/workflows/test.yml
     with:
       node: 20
-      os: macos-latest
+      os: macos-14
   Chrome:
     name: E2E Tests
     needs: prelim

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,13 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v2
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: "pnpm"


### PR DESCRIPTION
The M1 runner ended up being 20-25% faster to run CI on than `ubuntu` on the x86 runner, previously the fastest.
Update: Installing dependencies is still 3 times slower. For the amount of tests in this repo, it fails to break even.