### PR TITLE
new integration: client interaction - load and hydrate components after first interaction

### DIFF
--- a/.changeset/lucky-hounds-lick.md
+++ b/.changeset/lucky-hounds-lick.md
@@ -1,0 +1,5 @@
+---
+"astro-client-interaction": major
+---
+
+Initial release

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ A collection of purpose-built, small, third-party integrations for Astro.
 
 - **astro-adds-to-head** - fix a corner case in content collections rendering. [README](https://github.com/lilnasy/gratelets/tree/main/packages/adds-to-head) | [NPM](https://www.npmjs.com/package/astro-adds-to-head)
 - **astro-carton** - render components in isolation. [README](https://github.com/lilnasy/gratelets/tree/main/packages/carton) | [NPM](https://www.npmjs.com/package/astro-carton)
+- **astro-client-interaction** - load and hydrate framework components on first interaction. [README](https://github.com/lilnasy/gratelets/tree/main/packages/client-interaction) | [NPM](https://www.npmjs.com/package/astro-client-interaction)
 - **astro-dynamic-import** - let your CMS decide which components to include. [README](https://github.com/lilnasy/gratelets/tree/main/packages/dynamic-import) | [NPM](https://www.npmjs.com/package/astro-dynamic-import)
 - **astro-emotion** - CSS-in-Zero-JS using [Emotion](https://emotion.sh/). [README](https://github.com/lilnasy/gratelets/tree/main/packages/emotion) | [NPM](https://www.npmjs.com/package/astro-emotion)
 - **astro-global** - use the Astro global directly inside framework components and MDX pages. [README](https://github.com/lilnasy/gratelets/tree/main/packages/global) | [NPM](https://www.npmjs.com/package/astro-global)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "check": "tsc",
         "test": "pnpm --filter tests exec vitest --run --api.port 51204 --poolOptions.threads.singleThread --bail 1",
         "install:chromium": "pnpm --filter tests-e2e exec playwright install chromium",
-        "test:e2e": "pnpm --filter tests-e2e exec node --no-warnings --experimental-loader playwright/lib/transform/esmLoader node_modules/playwright/cli.js test --timeout 5000 -x"
+        "test:e2e": "pnpm --filter tests-e2e exec node --no-warnings --experimental-loader playwright/lib/transform/esmLoader node_modules/playwright/cli.js test --workers=1 --timeout 5000 -x"
     },
     "workspaces": [
         "packages/*"

--- a/packages/client-interaction/README.md
+++ b/packages/client-interaction/README.md
@@ -1,0 +1,52 @@
+# astro-client-interaction 👆
+
+This **[Astro integration][astro-integration]** ...
+
+- <strong>[Why astro-client-interaction?](#why-astro-client-interaction)</strong>
+- <strong>[Installation](#installation)</strong>
+- <strong>[Usage](#usage)</strong>
+- <strong>[Troubleshooting](#troubleshooting)</strong>
+- <strong>[Contributing](#contributing)</strong>
+- <strong>[Changelog](#changelog)</strong>
+
+## Why astro-client-interaction?
+
+## Installation
+
+### Manual Install
+
+First, install the `astro-client-interaction` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
+
+```sh
+npm install astro-client-interaction
+```
+
+Then, apply this integration to your `astro.config.*` file using the `integrations` property:
+
+```diff lang="js" "clientIx()"
+  // astro.config.mjs
+  import { defineConfig } from 'astro/config';
++ import clienIx from 'astro-client-interaction';
+
+  export default defineConfig({
+    // ...
+    integrations: [clienIx()],
+    //             ^^^^^^^
+  });
+```
+
+## Usage
+
+## Troubleshooting
+
+For help, check out the `Discussions` tab on the [GitHub repo](https://github.com/lilnasy/gratelets/discussions).
+
+## Contributing
+
+This package is maintained by [lilnasy](https://github.com/lilnasy) independently from Astro. The integration code is located at [packages/client-interaction/integration.ts](https://github.com/lilnasy/gratelets/blob/main/packages/client-interaction/integration.ts). You're welcome to contribute by submitting an issue or opening a PR!
+
+## Changelog
+
+See [CHANGELOG.md](https://github.com/lilnasy/gratelets/blob/main/packages/client-interaction/CHANGELOG.md) for a history of changes to this integration.
+
+[astro-integration]: https://docs.astro.build/en/guides/integrations-guide/

--- a/packages/client-interaction/README.md
+++ b/packages/client-interaction/README.md
@@ -1,6 +1,6 @@
 # astro-client-interaction 👆
 
-This **[Astro integration][astro-integration]** ...
+This **[Astro integration][astro-integration]** lets you load and hydrate framework components on first interaction by introducing the `client:interaction` directive.
 
 - <strong>[Why astro-client-interaction?](#why-astro-client-interaction)</strong>
 - <strong>[Installation](#installation)</strong>
@@ -10,6 +10,8 @@ This **[Astro integration][astro-integration]** ...
 - <strong>[Changelog](#changelog)</strong>
 
 ## Why astro-client-interaction?
+
+This integration is useful when you have several components that may never be interacted with, and are non-essential to your visitors' experience. Delaying their loading and hydration can help improve the performance of your site by reducing the amount of bandwidth usage and main-thread work that needs to be done on the initial page load.
 
 ## Installation
 
@@ -36,6 +38,15 @@ Then, apply this integration to your `astro.config.*` file using the `integratio
 ```
 
 ## Usage
+
+Once the integration is installed and added to the configuration file, you can add the `client:interaction` directive to any component that should only hydrate after the visitor presses a key, clicks or touches any part of the page.
+
+```astro
+---
+import Component from "../components/Counter.jsx"
+---
+<Component client:interaction />
+```
 
 ## Troubleshooting
 

--- a/packages/client-interaction/integration.ts
+++ b/packages/client-interaction/integration.ts
@@ -1,0 +1,17 @@
+import type { AstroIntegration } from "astro"
+
+interface Options {}
+
+export default function (_: Partial<Options> = {}): AstroIntegration {
+    return {
+        name: "astro-client-interaction",
+        hooks: {
+            "astro:config:setup" ({ addClientDirective }) {
+                addClientDirective({
+                    name: "interaction",
+                    entrypoint: "astro-client-interaction/runtime/directive.ts"
+                })
+            }
+        }
+    }
+}

--- a/packages/client-interaction/integration.ts
+++ b/packages/client-interaction/integration.ts
@@ -1,4 +1,10 @@
-import type { AstroIntegration } from "astro"
+import { type AstroIntegration } from "astro"
+
+declare module "astro" {
+    interface AstroClientDirectives {
+        "client:interaction"?: boolean
+    }
+}
 
 interface Options {}
 

--- a/packages/client-interaction/package.json
+++ b/packages/client-interaction/package.json
@@ -1,7 +1,7 @@
 {
     "name": "astro-client-interaction",
     "version": "0.0.0",
-    "description": "",
+    "description": "Load and hydrate framework components after first interaction by adding a `client:interaction` directive.",
     "author": "Arsh",
     "license": "Public Domain",
     "keywords": [

--- a/packages/client-interaction/package.json
+++ b/packages/client-interaction/package.json
@@ -23,7 +23,7 @@
         "./runtime/*": "./runtime/*"
     },
     "scripts": {
-        "test": "pnpm -w test tests/client-interaction.test.ts"
+        "test": "pnpm -w test:e2e client-interaction.spec.ts"
     },
     "type": "module",
     "peerDependencies": {

--- a/packages/client-interaction/package.json
+++ b/packages/client-interaction/package.json
@@ -1,0 +1,35 @@
+{
+    "name": "astro-client-interaction",
+    "version": "0.0.0",
+    "description": "",
+    "author": "Arsh",
+    "license": "Public Domain",
+    "keywords": [
+        "withastro",
+        "astro-component"
+    ],
+    "homepage": "https://github.com/lilnasy/gratelets/tree/main/packages/client-interaction",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/lilnasy/gratelets",
+        "directory": "packages/client-interaction"
+    },
+    "files": [
+        "integration.ts",
+        "runtime"
+    ],
+    "exports": {
+        ".": "./integration.ts",
+        "./runtime/*": "./runtime/*"
+    },
+    "scripts": {
+        "test": "pnpm -w test tests/client-interaction.test.ts"
+    },
+    "type": "module",
+    "peerDependencies": {
+        "astro": "4"
+    },
+    "devDependencies": {
+        "@types/node": "20"
+    }
+}

--- a/packages/client-interaction/package.json
+++ b/packages/client-interaction/package.json
@@ -1,7 +1,7 @@
 {
     "name": "astro-client-interaction",
     "version": "0.0.0",
-    "description": "Load and hydrate framework components after first interaction by adding a `client:interaction` directive.",
+    "description": "Load and hydrate framework components on first interaction by adding a `client:interaction` directive.",
     "author": "Arsh",
     "license": "Public Domain",
     "keywords": [

--- a/packages/client-interaction/runtime/directive.ts
+++ b/packages/client-interaction/runtime/directive.ts
@@ -1,0 +1,16 @@
+const firstInteraction = new Promise<void>(resolve => {
+    const controller = new AbortController;
+    for (const event of [ "keydown", "mousedown", "pointerdown", "touchstart" ]) {
+        document.addEventListener(
+            event,
+            () => (resolve(), controller.abort()),
+            { once: true, passive: true, signal: controller.signal }
+        )
+    }
+})
+
+export default (async load => {
+    await firstInteraction
+    const hydrate = await load()
+    await hydrate()
+}) satisfies import('astro').ClientDirective

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,16 @@ importers:
         specifier: '5.3'
         version: 5.3.3
 
+  packages/client-interaction:
+    dependencies:
+      astro:
+        specifier: '4'
+        version: 4.3.2(@types/node@20.11.16)(typescript@5.3.3)
+    devDependencies:
+      '@types/node':
+        specifier: '20'
+        version: 20.11.16
+
   packages/dynamic-import:
     dependencies:
       astro:
@@ -184,6 +194,24 @@ importers:
         specifier: 1.40.1
         version: 1.40.1
 
+  tests-e2e/fixtures/client-interaction:
+    dependencies:
+      '@astrojs/mdx':
+        specifier: '2'
+        version: 2.1.1(astro@4.3.2)
+      '@astrojs/preact':
+        specifier: '3'
+        version: 3.1.0(@babel/core@7.23.9)(preact@10.19.3)(vite@5.0.12)
+      astro:
+        specifier: '4'
+        version: 4.3.2(@types/node@20.11.16)(typescript@5.3.3)
+      astro-client-interaction:
+        specifier: workspace:*
+        version: link:../../../packages/client-interaction
+      preact:
+        specifier: '10'
+        version: 10.19.3
+
   tests-e2e/fixtures/typed-api:
     dependencies:
       '@astrojs/node':
@@ -210,6 +238,24 @@ importers:
       astro-adds-to-head:
         specifier: workspace:*
         version: link:../../../packages/adds-to-head
+
+  tests/fixtures/client-interaction:
+    dependencies:
+      '@astrojs/mdx':
+        specifier: '2'
+        version: 2.1.1(astro@4.3.2)
+      '@astrojs/preact':
+        specifier: '3'
+        version: 3.1.0(@babel/core@7.23.9)(preact@10.19.3)(vite@5.0.12)
+      astro:
+        specifier: '4'
+        version: 4.3.2(@types/node@20.11.16)(typescript@5.3.3)
+      astro-client-interaction:
+        specifier: workspace:*
+        version: link:../../../packages/client-interaction
+      preact:
+        specifier: '10'
+        version: 10.19.3
 
   tests/fixtures/dynamic-import:
     dependencies:
@@ -5087,7 +5133,7 @@ packages:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.3
-      mdast-util-to-hast: 13.0.2
+      mdast-util-to-hast: 13.1.0
       unified: 11.0.4
       vfile: 6.0.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,24 +239,6 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/adds-to-head
 
-  tests/fixtures/client-interaction:
-    dependencies:
-      '@astrojs/mdx':
-        specifier: '2'
-        version: 2.1.1(astro@4.3.2)
-      '@astrojs/preact':
-        specifier: '3'
-        version: 3.1.0(@babel/core@7.23.9)(preact@10.19.3)(vite@5.0.12)
-      astro:
-        specifier: '4'
-        version: 4.3.2(@types/node@20.11.16)(typescript@5.3.3)
-      astro-client-interaction:
-        specifier: workspace:*
-        version: link:../../../packages/client-interaction
-      preact:
-        specifier: '10'
-        version: 10.19.3
-
   tests/fixtures/dynamic-import:
     dependencies:
       astro:

--- a/tests-e2e/client-interaction.spec.ts
+++ b/tests-e2e/client-interaction.spec.ts
@@ -1,0 +1,17 @@
+import type { Page } from "playwright/test"
+import { testFactory } from "./utils.ts"
+import { expect } from "playwright/test"
+
+const test = testFactory("./fixtures/client-interaction")
+
+test("dev mode - components hydrates after click", ({ dev, page }) => basics(page))
+test("stopping dev server", ({ dev }) => dev.stop())
+test("production build - components hydrates after click", ({ preview, page }) => basics(page))
+test("stopping preview server", ({ preview }) => preview.stop())
+
+async function basics(page: Page) {
+    await page.goto("http://localhost:4321/")
+    await expect(page.locator("#counter-message")).toHaveText("server rendered")
+    await page.click("body")
+    await expect(page.locator("#counter-message")).toHaveText("hydrated")
+}

--- a/tests-e2e/fixtures/client-interaction/astro.config.ts
+++ b/tests-e2e/fixtures/client-interaction/astro.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "astro/config"
+import preact from "@astrojs/preact"
+import clientIx from "astro-client-interaction"
+
+// https://astro.build/config
+export default defineConfig({
+	integrations: [preact(), clientIx()],
+})

--- a/tests-e2e/fixtures/client-interaction/package.json
+++ b/tests-e2e/fixtures/client-interaction/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "@test/global",
+    "private": true,
+    "dependencies": {
+        "@astrojs/mdx": "2",
+        "@astrojs/preact": "3",
+        "astro": "4",
+        "astro-client-interaction": "workspace:*",
+        "preact": "10"
+    }
+}

--- a/tests-e2e/fixtures/client-interaction/src/components/Counter.jsx
+++ b/tests-e2e/fixtures/client-interaction/src/components/Counter.jsx
@@ -1,0 +1,18 @@
+import { useState } from "preact/hooks"
+
+export default function Counter() {
+	const [count, setCount] = useState(0);
+	const add = () => setCount((i) => i + 1);
+	const subtract = () => setCount((i) => i - 1);
+
+	return (
+		<>
+			<div class="counter">
+				<button onClick={subtract}>-</button>
+				<pre>{count}</pre>
+				<button onClick={add}>+</button>
+			</div>
+			<div id="counter-message">{import.meta.env.SSR ? "server rendered" : "hydrated"}</div>
+		</>
+	);
+}

--- a/tests-e2e/fixtures/client-interaction/src/pages/index.astro
+++ b/tests-e2e/fixtures/client-interaction/src/pages/index.astro
@@ -1,0 +1,4 @@
+---
+import Component from "../components/Counter.jsx"
+---
+<Component client:interaction />

--- a/tests-e2e/utils.ts
+++ b/tests-e2e/utils.ts
@@ -21,6 +21,7 @@ export function testFactory(relativeRootPath: `./fixtures/${string}`, options?: 
     let adapterServer: TestExtension["adapter"]
     let previewServer: PreviewServer
     const root = new URL(relativeRootPath, import.meta.url)
+    // HACK: vite fails to resolve libraries unless cwd matches project root
     process.chdir(url.fileURLToPath(root))
     const test = base.extend<TestExtension>({
         async page({ page }, use) {

--- a/tests-e2e/utils.ts
+++ b/tests-e2e/utils.ts
@@ -1,3 +1,4 @@
+import url from "node:url"
 import type { AstroInlineConfig } from "astro"
 import type { createExports } from "@astrojs/node/server.js"
 //@ts-expect-error
@@ -20,6 +21,7 @@ export function testFactory(relativeRootPath: `./fixtures/${string}`, options?: 
     let adapterServer: TestExtension["adapter"]
     let previewServer: PreviewServer
     const root = new URL(relativeRootPath, import.meta.url)
+    process.chdir(url.fileURLToPath(root))
     const test = base.extend<TestExtension>({
         async page({ page }, use) {
             // doing this here avoids needing to create playwright.config.ts

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -39,7 +39,13 @@ export async function dev(root: `./fixtures/${string}` | URL, options: Astro.Ast
     }
 }
 
-async function command<Command extends "dev" | "build">(
+export type PreviewServer = Astro.PreviewServer
+
+export async function preview(root: `./fixtures/${string}` | URL, options: Astro.AstroInlineConfig = {}) {
+    return await command("preview", root, options)
+}
+
+async function command<Command extends "dev" | "build" | "preview">(
     command: Command,
     root_: string | URL,
     options?: Astro.AstroInlineConfig
@@ -60,7 +66,10 @@ async function command<Command extends "dev" | "build">(
             },
             ...options?.vite
         }
-    }) as Command extends "dev" ? ReturnType<typeof Astro.dev> : void
+    }) as
+        Command extends "dev" ? ReturnType<typeof Astro.dev> :
+        Command extends "preview" ?  ReturnType<typeof Astro.preview> :
+        void
 }
 
 export const testAdapter: Astro.AstroIntegration = {


### PR DESCRIPTION
# Changes
- Introduces a client directive `client:interaction`, that loads and hydrated the component after first interaction (click, touch, keypress)

# Testing
Implemented - running into vite bugs.

# Docs
- [x] Package readme
- [ ] Repository readme