### PR TITLE
qol(typed api): manually catch errors in dev mode

### DIFF
--- a/.changeset/six-dancers-peel.md
+++ b/.changeset/six-dancers-peel.md
@@ -1,0 +1,5 @@
+---
+"astro-typed-api": patch
+---
+
+Prevents error overlay from appearing in dev mode for user errors. Astro's error overlay appears whenever a server side error occurs. For server-side rendering html, it's important to pay attention to them. However, for APIs, an error is just another response - it is unintended for it to take over the browser.

--- a/packages/typed-api/runtime/server-internals.ts
+++ b/packages/typed-api/runtime/server-internals.ts
@@ -62,7 +62,17 @@ export function createApiRoute(fetch: (input: unknown, content: TypedAPIContext)
             output = await fetch(input, context)
         } catch (error) {
             if (error instanceof TypedAPIError) throw error
-            throw new ProcedureFailed(error, url)
+            const procedureFailed = new ProcedureFailed(error, url)
+            if (import.meta.env.DEV) {
+                // some errors are thrown intentionally
+                // until a full error handling api is implemented, manually return 500 responses
+                // to avoid dev overlay taking over the browser
+                console.error(procedureFailed)
+                return new Response(null, { status: 500 })
+            }
+            else {
+                throw procedureFailed
+            }
         }
         
         let outputBody


### PR DESCRIPTION
# Changes
- Errors are now manually handled to return a 500 response, instead of letting the dev server handle it. This prevents errors taking over the browser with the error overlay.
- Addresses #78

# Testing
Existing tests should pass.

# Docs
Does not affect usage.