### PR TITLE
feat(client-interaction): Supporting idle option

### DIFF
--- a/.changeset/two-lizards-burn.md
+++ b/.changeset/two-lizards-burn.md
@@ -1,0 +1,14 @@
+---
+"astro-client-interaction": minor
+---
+
+Introduces the "idle" value to the `client:interaction` directive. When set, an interaction will schedule the loading of the component for when the browser is idle, instead of loading it immediately.
+
+```astro
+---
+import Component from "../components/Counter.jsx"
+---
+<Component client:interaction="idle" />
+```
+
+By default, a component with the `client:interaction` directive could be loaded before or after the ones with the `client:idle` directive, depending on the timing of the first interaction. This feature allows `client:interaction` components to predictably lower loading priority than `client:idle` components.

--- a/packages/client-interaction/README.md
+++ b/packages/client-interaction/README.md
@@ -48,6 +48,17 @@ import Component from "../components/Counter.jsx"
 <Component client:interaction />
 ```
 
+Interactions may happen while the page is loading. This means that components with the `client:interaction` directive sometimes get loaded before the ones with the `client:idle` directive. This behavior becomes problematic if you use directives to designate "priorities" to components. To make sure that `client:interaction` components are always treated as lower priority than `client:idle`, you can set the value of `client:interaction` to "idle".
+
+```astro
+---
+import Component from "../components/Counter.jsx"
+---
+<Component client:interaction="idle" />
+```
+
+When the "idle" value is set, an interaction will be schedule the loading of the component for when the browser is idle, instead of loading it immediately on interaction.
+
 ## Troubleshooting
 
 For help, check out the `Discussions` tab on the [GitHub repo](https://github.com/lilnasy/gratelets/discussions).

--- a/packages/client-interaction/integration.ts
+++ b/packages/client-interaction/integration.ts
@@ -2,7 +2,21 @@ import { type AstroIntegration } from "astro"
 
 declare module "astro" {
     interface AstroClientDirectives {
-        "client:interaction"?: boolean
+        /**
+         * The `client:interaction` directive allows you to delay the hydration of a component until the user interacts with the page.
+         * 
+         * ```jsx
+         * <Component client:interaction />
+         * ```
+         * 
+         * Interactions may happen while the page is still loading.
+         * Setting the value of the directive to "idle" allows to defer loading until the browser is also idle.
+         * 
+         * ```jsx
+         * <Component client:interaction="idle" />
+         * ```
+         */
+        "client:interaction"?: boolean | "idle"
     }
 }
 

--- a/packages/client-interaction/runtime/directive.ts
+++ b/packages/client-interaction/runtime/directive.ts
@@ -9,8 +9,20 @@ const firstInteraction = new Promise<void>(resolve => {
     }
 })
 
-export default (async load => {
+export default (async (load, opts) => {
     await firstInteraction
-    const hydrate = await load()
-    await hydrate()
+    const hy = async () => {
+        const hydrate = await load()
+        await hydrate()
+    }
+    const arrOpts = Array.isArray(opts.value) ? opts.value : [opts.value]
+    if (arrOpts.includes('idle')) {
+        if (typeof window.requestIdleCallback === 'function') {
+            window.requestIdleCallback(hy)
+            return
+        }
+        setTimeout(hy, 100)
+        return
+    }
+    hy()
 }) satisfies import('astro').ClientDirective

--- a/packages/client-interaction/runtime/directive.ts
+++ b/packages/client-interaction/runtime/directive.ts
@@ -15,8 +15,7 @@ export default (async (load, opts) => {
         const hydrate = await load()
         await hydrate()
     }
-    const arrOpts = Array.isArray(opts.value) ? opts.value : [opts.value]
-    if (arrOpts.includes('idle')) {
+    if (opts.value === 'idle') {
         if (typeof window.requestIdleCallback === 'function') {
             window.requestIdleCallback(hy)
             return

--- a/tests-e2e/client-interaction.spec.ts
+++ b/tests-e2e/client-interaction.spec.ts
@@ -4,13 +4,24 @@ import { expect } from "playwright/test"
 
 const test = testFactory("./fixtures/client-interaction")
 
-test("dev mode - components hydrates after click", ({ dev, page }) => basics(page))
+test("dev mode - directive makes the component hydrate after click", ({ dev, page }) => basics(page))
+test("dev mode - idle value makes the component hydrate after click", ({ dev, page }) => idle(page))
 test("stopping dev server", ({ dev }) => dev.stop())
-test("production build - components hydrates after click", ({ preview, page }) => basics(page))
+test("production build - directive makes the component hydrate after click", ({ preview, page }) => basics(page))
+test("production build - idle value makes the component hydrate after click", ({ preview, page }) => idle(page))
 test("stopping preview server", ({ preview }) => preview.stop())
 
 async function basics(page: Page) {
     await page.goto("http://localhost:4321/")
+    await expect(page.locator("#counter-message")).toHaveText("server rendered")
+    await page.click("body")
+    await expect(page.locator("#counter-message")).toHaveText("hydrated")
+}
+
+// the nuances of how idle directive makes the component load cant be tested
+// we check that it at least loads eventually
+async function idle(page: Page) {
+    await page.goto("http://localhost:4321/idle")
     await expect(page.locator("#counter-message")).toHaveText("server rendered")
     await page.click("body")
     await expect(page.locator("#counter-message")).toHaveText("hydrated")

--- a/tests-e2e/fixtures/client-interaction/src/pages/idle.astro
+++ b/tests-e2e/fixtures/client-interaction/src/pages/idle.astro
@@ -1,0 +1,4 @@
+---
+import Component from "../components/Counter.jsx"
+---
+<Component client:interaction="idle" />


### PR DESCRIPTION
Use `client:interaction="idle"` for first interaction -> idle callback -> hydrate