### PR TITLE
dynamic imports: prevent repeated scripts and styles

### DIFF
--- a/.changeset/real-boxes-whisper.md
+++ b/.changeset/real-boxes-whisper.md
@@ -1,0 +1,5 @@
+---
+"astro-dynamic-import": minor
+---
+
+Dynamic imports are now even more optimized. Multiple uses of the same dynamically imported component will result in only one addition of the necessary scripts and styles.

--- a/packages/dynamic-import/package.json
+++ b/packages/dynamic-import/package.json
@@ -27,7 +27,7 @@
         }
     },
     "scripts": {
-        "test": "pnpm -w test tests/dynamic-import.test.ts"
+        "test": "pnpm -w test dynamic-import.test.ts"
     },
     "type": "module",
     "peerDependencies": {

--- a/packages/dynamic-import/runtime/virtual-module.ts
+++ b/packages/dynamic-import/runtime/virtual-module.ts
@@ -14,7 +14,8 @@ import { srcDirName, lookupMap as _lookupMap } from "astro-dynamic-import:intern
 import type { SSRResult } from "astro"
 
 const lookupMap: Record<string, Promise<AstroComponentFactory>> = {}
-const processed: Array<string> = [];
+let pathname: String = "";
+let processed: Array<string> = [];
 
 export default async function(srcRelativeSpecifier: string) {
     const absoluteSpecifier = path.posix.join("/", srcDirName, srcRelativeSpecifier)
@@ -39,6 +40,10 @@ async function lazyImportToComponent(absoluteSpecifier: string, importable: any)
     const componentModule = await getMod()
     return createComponent({
         factory(result: SSRResult, props: Record<string, unknown>, slots: Record<string, unknown>) {
+            if (pathname !== result.pathname) {
+                processed = [];
+                pathname = result.pathname;
+            }
             const component = componentModule.default
             let styles = "";
             let links = "";

--- a/tests/fixtures/dynamic-import/src/pages/multiple-instances.astro
+++ b/tests/fixtures/dynamic-import/src/pages/multiple-instances.astro
@@ -1,0 +1,8 @@
+---
+import dynamic from "astro:import"
+
+const Component = await dynamic(`components/A.astro`)
+---
+<Component/>
+<Component/>
+<Component/>


### PR DESCRIPTION
Hi @lilnasy!

## Background

I've been working through a proof of concept Astro implementation that pulls content from a CMS (in my case Sanity) and went down the rabbit hole of noticing that all components styling and JS dependencies get loaded on every page regardless of whether they're used or not.

I came across [this roadmap discussion](https://github.com/withastro/roadmap/discussions/664) that mentioned your dynamic-import integration and was very excited to give it a try.

From my initial testing, it does indeed isolate dependencies on a per-page basis Though as I dug in a bit further with more complex pages, I noticed that if a component was used on the page more than once then the style and JavaScript dependencies are added to the page that same number of times. It doesn't affect the page rendering but does add a considerable amount to the pageload/

## This Proof of Concept

Rather than just opening an issue, I wanted to dive in further and understand what's going on first, and then offer a suggestion. This is a bit of a crude example, and I'm sure it can be refined, but it gets the job done.

This addition keeps track of the components that have been processed in `processed`, if it was already then the styles, links, and scripts are suppressed so they don't get added again.

In my tests, the page still renders fine and I don't see duplicate styles or JS in using the standard dev or build commands.