### PR TITLE
chore(ci): exclude submodules when creating release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm exec changeset version
+          version: sh .github/workflows/version.sh
           publish: pnpm exec changeset publish
           commit: "[ci] release"
           title: "[ci] release"

--- a/.github/workflows/version.sh
+++ b/.github/workflows/version.sh
@@ -1,0 +1,3 @@
+pnpm exec changeset version
+# reset submodules so that they are not included in release pr
+git submodule update --init


### PR DESCRIPTION
- After running the versioning command, the `changeset/action`'s "version" workflow changesets actions would also commit the submodules to their patched commit refs.
- Since these refs don't exist in the upstream repo, the "release" workflow would fail.
- Updated the version command to reset the submodules after updating the changelog and the version in `package.json`. 