### PR TITLE
New integration: Cloudflare adapter with WebSocket

### DIFF
--- a/.changeset/strange-pandas-perform.md
+++ b/.changeset/strange-pandas-perform.md
@@ -1,0 +1,5 @@
+---
+"astro-cloudflare-websocket": major
+---
+
+Initial release

--- a/.github/workflows/init-submodules.sh
+++ b/.github/workflows/init-submodules.sh
@@ -17,3 +17,9 @@ git config user.email "ci@c.i"
 git config user.name "CI"
 git am ../../*.patch
 cd ../../../..
+
+cd packages/cloudflare-websocket/withastro/adapters
+git config user.email "ci@c.i"
+git config user.name "CI"
+git am ../../*.patch
+cd ../../../..

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/dist
 **/dist_*
 **/.astro
+tests/.wrangler

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,10 @@
 	shallow = true
 	ignore = all
 	active = false
+[submodule "packages/cloudflare-websocket/withastro/adapters"]
+	path = packages/cloudflare-websocket/withastro/adapters
+	url = https://github.com/withastro/adapters
+	branch = cloudflare-astro-v5
+	shallow = true
+	ignore = all
+	active = false

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,26 +3,22 @@
 	url = https://github.com/withastro/adapters
 	branch = main
 	shallow = true
-	ignore = all
 	active = false
 [submodule "packages/bun-websocket/NuroDev/astro-bun"]
 	path = packages/bun-websocket/NuroDev/astro-bun
 	url = https://github.com/NuroDev/astro-bun
 	branch = main
 	shallow = true
-	ignore = all
 	active = false
 [submodule "packages/deno-websocket/denoland/deno-astro-adapter"]
 	path = packages/deno-websocket/denoland/deno-astro-adapter
 	url = https://github.com/denoland/deno-astro-adapter
 	branch = main
 	shallow = true
-	ignore = all
 	active = false
 [submodule "packages/cloudflare-websocket/withastro/adapters"]
 	path = packages/cloudflare-websocket/withastro/adapters
 	url = https://github.com/withastro/adapters
 	branch = cloudflare-astro-v5
 	shallow = true
-	ignore = all
 	active = false

--- a/packages/cloudflare-websocket/0001-add-implementation.patch
+++ b/packages/cloudflare-websocket/0001-add-implementation.patch
@@ -1,4 +1,4 @@
-From dda8e2a452507dccc8c3a75bbd33e593e817304e Mon Sep 17 00:00:00 2001
+From ca2eca04c0f396de4d8b78d65d90ebb6ae05796d Mon Sep 17 00:00:00 2001
 From: Arsh <69170106+lilnasy@users.noreply.github.com>
 Date: Sun, 22 Dec 2024 01:07:20 +0530
 Subject: [PATCH 1/3] add implementation

--- a/packages/cloudflare-websocket/0001-add-implementation.patch
+++ b/packages/cloudflare-websocket/0001-add-implementation.patch
@@ -1,4 +1,4 @@
-From d6e9cee9f2cd24ea5830a122dfd6d35e0dcba018 Mon Sep 17 00:00:00 2001
+From dda8e2a452507dccc8c3a75bbd33e593e817304e Mon Sep 17 00:00:00 2001
 From: Arsh <69170106+lilnasy@users.noreply.github.com>
 Date: Sun, 22 Dec 2024 01:07:20 +0530
 Subject: [PATCH 1/3] add implementation
@@ -6,10 +6,10 @@ Subject: [PATCH 1/3] add implementation
 ---
  .../src/websocket/cloudflare-websocket.ts     |   4 +
  .../cloudflare/src/websocket/dev-attach.ts    |  17 ++
- .../src/websocket/dev-middleware.ts           | 179 +++++++++++++++++
+ .../src/websocket/dev-middleware.ts           | 177 +++++++++++++++++
  .../cloudflare/src/websocket/dev-response.ts  |  51 +++++
  .../cloudflare/src/websocket/dev-websocket.ts | 183 ++++++++++++++++++
- 5 files changed, 434 insertions(+)
+ 5 files changed, 432 insertions(+)
  create mode 100644 packages/cloudflare/src/websocket/cloudflare-websocket.ts
  create mode 100644 packages/cloudflare/src/websocket/dev-attach.ts
  create mode 100644 packages/cloudflare/src/websocket/dev-middleware.ts
@@ -52,10 +52,10 @@ index 00000000..f72f6971
 +}
 diff --git a/packages/cloudflare/src/websocket/dev-middleware.ts b/packages/cloudflare/src/websocket/dev-middleware.ts
 new file mode 100644
-index 00000000..478e347f
+index 00000000..453fbc83
 --- /dev/null
 +++ b/packages/cloudflare/src/websocket/dev-middleware.ts
-@@ -0,0 +1,179 @@
+@@ -0,0 +1,177 @@
 +import { AsyncLocalStorage } from "node:async_hooks"
 +import type { APIContext, MiddlewareNext } from "astro"
 +import type { ViteDevServer, Connect } from "vite"
@@ -156,6 +156,15 @@ index 00000000..478e347f
 +        })
 +        return next()
 +    }
++    Object.assign(context.locals, {
++        isUpgradeRequest: true,
++        upgradeWebSocket() {
++            const response = newUpgradeResponse()
++            const socket = newWebSocket()
++            responseToSocketMap.set(response, socket)
++            return { socket, response }
++        }
++    })
 +
 +    let response: Response | undefined
 +    let error: unknown
@@ -198,16 +207,6 @@ index 00000000..478e347f
 +    throw new Error("Unknown error", { cause: error })
 +}
 +
-+const devLocals = {
-+    isUpgradeRequest: true,
-+    upgradeWebSocket() {
-+        const response = newUpgradeResponse()
-+        const socket = newWebSocket()
-+        responseToSocketMap.set(response, socket)
-+        return { socket, response }
-+    }
-+}
-+
 +export function handleUpgradeRequests(viteDevServer: ViteDevServer) {
 +
 +    const astroDevHandler =
@@ -223,7 +222,6 @@ index 00000000..478e347f
 +
 +    httpServer.on("upgrade", (req, socket, head) => {
 +        if (req.headers["sec-websocket-protocol"] === "vite-hmr") return
-+        (req as any)[Symbol.for("astro.locals")] = devLocals
 +        upgradeRequestStorage.run([ wsServer, req, socket, head ], astroDevHandler, req, fakeResponse)
 +    })
 +}

--- a/packages/cloudflare-websocket/0001-add-implementation.patch
+++ b/packages/cloudflare-websocket/0001-add-implementation.patch
@@ -1,0 +1,486 @@
+From d6e9cee9f2cd24ea5830a122dfd6d35e0dcba018 Mon Sep 17 00:00:00 2001
+From: Arsh <69170106+lilnasy@users.noreply.github.com>
+Date: Sun, 22 Dec 2024 01:07:20 +0530
+Subject: [PATCH 1/3] add implementation
+
+---
+ .../src/websocket/cloudflare-websocket.ts     |   4 +
+ .../cloudflare/src/websocket/dev-attach.ts    |  17 ++
+ .../src/websocket/dev-middleware.ts           | 179 +++++++++++++++++
+ .../cloudflare/src/websocket/dev-response.ts  |  51 +++++
+ .../cloudflare/src/websocket/dev-websocket.ts | 183 ++++++++++++++++++
+ 5 files changed, 434 insertions(+)
+ create mode 100644 packages/cloudflare/src/websocket/cloudflare-websocket.ts
+ create mode 100644 packages/cloudflare/src/websocket/dev-attach.ts
+ create mode 100644 packages/cloudflare/src/websocket/dev-middleware.ts
+ create mode 100644 packages/cloudflare/src/websocket/dev-response.ts
+ create mode 100644 packages/cloudflare/src/websocket/dev-websocket.ts
+
+diff --git a/packages/cloudflare/src/websocket/cloudflare-websocket.ts b/packages/cloudflare/src/websocket/cloudflare-websocket.ts
+new file mode 100644
+index 00000000..95a728dc
+--- /dev/null
++++ b/packages/cloudflare/src/websocket/cloudflare-websocket.ts
+@@ -0,0 +1,4 @@
++// Cloudflare's WebSocket implementation's public API
++// already resembles the Web standard WebSocket
++// interface. It can re-exported as is.
++export default WebSocket
+\ No newline at end of file
+diff --git a/packages/cloudflare/src/websocket/dev-attach.ts b/packages/cloudflare/src/websocket/dev-attach.ts
+new file mode 100644
+index 00000000..f72f6971
+--- /dev/null
++++ b/packages/cloudflare/src/websocket/dev-attach.ts
+@@ -0,0 +1,17 @@
++import type * as ws from "ws"
++import type { WebSocket } from "./dev-websocket.js"
++
++/**
++ * To keep the internals hidden, the function that attaches the
++ * ws.WebSocket to the WebSocket instance is created within
++ * WebSocket's static block, and assigned to this variable.
++ */
++export const attacher: { attach: null | typeof attach } = { attach: null }
++
++/**
++ * Attach a ws.WebSocket connected to I/O to the implementation
++ * of the standard WebSocket class exposed to the public API.
++ */
++export function attach(standard: WebSocket, ws: ws.WebSocket): void {
++    return attacher.attach?.(standard, ws)
++}
+diff --git a/packages/cloudflare/src/websocket/dev-middleware.ts b/packages/cloudflare/src/websocket/dev-middleware.ts
+new file mode 100644
+index 00000000..478e347f
+--- /dev/null
++++ b/packages/cloudflare/src/websocket/dev-middleware.ts
+@@ -0,0 +1,179 @@
++import { AsyncLocalStorage } from "node:async_hooks"
++import type { APIContext, MiddlewareNext } from "astro"
++import type { ViteDevServer, Connect } from "vite"
++import * as ws from "ws"
++import { UpgradeResponse, writeResponseToSocket } from "./dev-response.js"
++import { WebSocket } from "./dev-websocket.js"
++import { attach as _attach } from "./dev-attach.js"
++
++type UpgradeHandler =
++    import("node:http").Server["on"] extends
++        (event: "upgrade", callback: infer UpgradeHandler) => unknown
++            ? UpgradeHandler
++            : never
++
++/**
++ * This is a storage for the upgrade request.
++ *
++ * When the dev http server receives an upgrade request,
++ * the required objects are put into the storage, and
++ * when an upgrade response is returned, the objects are
++ * retrieved from it to perform the upgrade.
++ *
++ * To prevent issues around compilation and module
++ * duplication in the dev server, the instance is
++ * assigned onto globalThis to keep it singular.
++ */
++const upgradeRequestStorage: AsyncLocalStorage<[
++    wsServer: ws.WebSocketServer,
++    ...Parameters<UpgradeHandler>
++]> =
++    // @ts-expect-error
++    globalThis.__upgradeRequestStorage ??= new AsyncLocalStorage
++
++const responseToSocketMap: WeakMap<Response, WebSocket> =
++    // @ts-expect-error
++    globalThis.__responseToSocketMap ??= new WeakMap
++
++
++/**
++ * Similar to how `upgradeRequestStorage` and `responseToSocketMap`
++ * are kept singular.
++ *
++ * Except here the latest versions are kept instead of the first
++ * versions because of how the astro config module is loaded.
++ *
++ * The astro config module is loaded by a temporary vite instance,
++ * which does not read `tsconfig.json`. As a result, all typescript
++ * code is compiled with `useDefineForClassFields: false`, which
++ * prevents `UpgradeResponse` from overriding the status field of
++ * `Response`.
++ *
++ * As a workaround, the current `UpgradeResponse` class is put onto
++ * `globalThis`. This replaces the `UpgradeResponse` class being
++ * used by the locals with the functional version that is compiled
++ * later, during the compilation of the project's middleware chain.
++ */
++// @ts-expect-error
++globalThis.__UpgradeResponse = UpgradeResponse
++
++function newUpgradeResponse(): UpgradeResponse {
++    // @ts-expect-error
++    return new globalThis.__UpgradeResponse
++}
++
++// @ts-expect-error
++globalThis.__WebSocket = WebSocket
++
++function newWebSocket(): WebSocket {
++    // @ts-expect-error
++    return new globalThis.__WebSocket
++}
++
++// @ts-expect-error
++globalThis.__attach = _attach
++
++function attach(...args: Parameters<typeof _attach>): void {
++    // @ts-expect-error
++    return globalThis.__attach(...args)
++}
++
++/**
++ * This dev-only middleware is responsible for all requests
++ * that have been made as a result of an upgrade request.
++ *
++ * It checks whether the request is running within the context
++ * of an `upgradeRequestStorage`, which are created below in
++ * `hookIntoViteDevServer()`, and only runs if it is.
++ */
++export const onRequest = async function websocketDevMiddleware(context: APIContext, next: MiddlewareNext) {
++    const upgradeRequest = upgradeRequestStorage.getStore()
++
++    if (upgradeRequest === undefined) {
++        Object.assign(context.locals, {
++            isUpgradeRequest: false,
++            upgradeWebSocket() {
++                throw new Error("The request must be an upgrade request to upgrade the connection to a WebSocket.")
++            }
++        })
++        return next()
++    }
++
++    let response: Response | undefined
++    let error: unknown
++
++    try {
++        response = await next()
++    } catch (e) {
++        error = e
++    }
++
++
++    if (response) {
++        if (response instanceof UpgradeResponse) {
++            const standardWebSocket = responseToSocketMap.get(response)!
++            const [ wsServer, req, socket, head ] = upgradeRequest
++            wsServer.handleUpgrade(req, socket, head, ws => attach(standardWebSocket, ws))
++        } else {
++            /**
++             * If there was an upgrade request, but the response
++             * did not accept the upgrade, the response still
++             * needs to be manually handled.
++             */
++            const socket = upgradeRequest[2]
++            await writeResponseToSocket(socket, response)
++        }
++        /**
++         * Since the astroDevHandler has been given a fake
++         * response object to write the response into, the
++         * response returned here will not result in any
++         * network I/O. It is effectively just logging the
++         * status code of the response to the terminal.
++         */
++        return response
++    }
++
++    await writeResponseToSocket(upgradeRequest[2], new Response(null, { status: 500 }))
++
++    if (error && error instanceof Error) throw error
++
++    throw new Error("Unknown error", { cause: error })
++}
++
++const devLocals = {
++    isUpgradeRequest: true,
++    upgradeWebSocket() {
++        const response = newUpgradeResponse()
++        const socket = newWebSocket()
++        responseToSocketMap.set(response, socket)
++        return { socket, response }
++    }
++}
++
++export function handleUpgradeRequests(viteDevServer: ViteDevServer) {
++
++    const astroDevHandler =
++        viteDevServer.middlewares.stack
++        .find(stackItem => "name" in stackItem.handle && stackItem.handle.name === "astroDevHandler")!
++        .handle as Connect.SimpleHandleFunction
++
++    const wsServer = new ws.WebSocketServer({ noServer: true })
++
++    // vite dev server may be http2 or may not exist if it runs in middleware mode
++    // neither of these cases are supported by the current implementation
++    const httpServer = viteDevServer.httpServer as import("node:http").Server
++
++    httpServer.on("upgrade", (req, socket, head) => {
++        if (req.headers["sec-websocket-protocol"] === "vite-hmr") return
++        (req as any)[Symbol.for("astro.locals")] = devLocals
++        upgradeRequestStorage.run([ wsServer, req, socket, head ], astroDevHandler, req, fakeResponse)
++    })
++}
++
++const fakeResponse = {
++    setHeader() {},
++    write() {},
++    writeHead() {},
++    end() {},
++    on() {},
++} as any as import("node:http").ServerResponse
+diff --git a/packages/cloudflare/src/websocket/dev-response.ts b/packages/cloudflare/src/websocket/dev-response.ts
+new file mode 100644
+index 00000000..78069b50
+--- /dev/null
++++ b/packages/cloudflare/src/websocket/dev-response.ts
+@@ -0,0 +1,51 @@
++import { pipeline } from "node:stream/promises"
++
++/**
++ * Custom subclass because spec-compliant Response objects can't have a status of 101.
++ */
++export class UpgradeResponse extends Response {
++    readonly status = 101
++}
++
++const { Headers } = globalThis
++
++/**
++ * The "upgrade" event callback doesn't provide a response object.
++ * If the userland code decides that protocol should not be upgraded,
++ * the rejection response must be manually streamed into the lower
++ * level socket.
++ */
++export async function writeResponseToSocket(socket: import("node:stream").Duplex, response: Response) {
++    const { headers, status, statusText } = response
++    let head = `HTTP/1.1 ${status} ${statusText}\r\n`
++    /**
++     * The `Headers` class will have made sure that it
++     * contains only valid header names and values.
++     *
++     * But we can't be sure that the prototypes of `Response`
++     * and `Headers` classes have not been tampered with.
++     *
++     * As a security measure, the headers are reconstructed
++     * here, performing the validation in the process.
++     *
++     * This function is not a hot path, it is only called
++     * when an upgrade request does not receive an upgrade
++     * response.
++     */
++    for (const [ header, value ] of new Headers(headers).entries()) {
++        head += header + ": " + value + "\r\n"
++    }
++    /**
++     * Windows has some odd streaming errors.
++     */
++    socket.on("error", console.error)
++    socket.write(head + "\r\n")
++    if (response.body) {
++        /**
++         * Astro is also going to attempt to read the body
++         * if it exists. Since streams can only be consumed
++         * once, we clone here.
++         */
++        await pipeline(response.clone().body!, socket)
++    }
++}
+diff --git a/packages/cloudflare/src/websocket/dev-websocket.ts b/packages/cloudflare/src/websocket/dev-websocket.ts
+new file mode 100644
+index 00000000..dd31a9b5
+--- /dev/null
++++ b/packages/cloudflare/src/websocket/dev-websocket.ts
+@@ -0,0 +1,183 @@
++import type * as ws from "ws"
++import { attacher } from "./dev-attach.js"
++
++type WebSocketInterface = globalThis.WebSocket
++
++export class WebSocket extends EventTarget implements WebSocketInterface {
++
++    static readonly CONNECTING = 0 as const
++    static readonly OPEN       = 1 as const
++    static readonly CLOSING    = 2 as const
++    static readonly CLOSED     = 3 as const
++
++    get url() {
++        return this.#ws?.url ?? ""
++    }
++
++
++    // ready state
++
++    // Describing the fields here would put
++    // them on the individual instances, but
++    // they should go on the prototype instead.
++    // Thererfore, they are assigned onto the
++    // prototype in the static block below.
++    declare readonly CONNECTING: 0
++    declare readonly OPEN      : 1
++    declare readonly CLOSING   : 2
++    declare readonly CLOSED    : 3
++
++    get readyState() {
++        return this.#ws?.readyState ?? this.CONNECTING
++    }
++
++    get bufferedAmount() {
++        return this.#ws?.bufferedAmount ?? 0
++    }
++
++
++    // networking
++
++    onopen : WebSocketInterface["onopen"]  = null
++    onerror: WebSocketInterface["onerror"] = null
++    onclose: WebSocketInterface["onclose"] = null
++
++    get extensions() {
++        return this.#ws?.extensions ?? ""
++    }
++
++    get protocol() {
++        return this.#ws?.protocol ?? ""
++    }
++
++    close() {
++        if (this.#ws) this.#ws.close()
++        else this.addEventListener("open", () => this.close(), { once: true })
++    }
++
++
++    // messaging
++
++    onmessage : WebSocketInterface["onmessage"] = null
++
++    get binaryType() {
++        return this.#ws?.binaryType as "arraybuffer" | "blob" ?? "blob"
++    }
++
++    set binaryType(value: "arraybuffer" | "blob") {
++        // There's nothing stopping the user from setting the binary type
++        // to either `"nodebuffer"` or `"fragments"`, just type errors.
++        // Deviating from the standard `WebSocket` interface to properly
++        // support it, however, will come at the cost of portability.
++        if (this.#ws) {
++            // @ts-expect-error `"blob"` is supported by `ws`
++            this.#ws.binaryType = value
++        } else {
++            this.addEventListener("open", () => this.binaryType = value, { once: true })
++        }
++    }
++
++    send(data: string | ArrayBufferLike | Blob | ArrayBufferView) {
++        if (data instanceof Blob) data.arrayBuffer().then(buffer => this.#ws!.send(buffer))
++        else this.#ws!.send(data)
++    }
++
++
++    // implementation details
++
++    // the half-web-compatible WebSocket implementation of "ws"
++    #ws: ws.WebSocket | undefined
++
++    static {
++
++        Object.assign(this.prototype, {
++            CONNECTING: 0,
++            OPEN      : 1,
++            CLOSING   : 2,
++            CLOSED    : 3
++        })
++
++        // Freeze the prototype and class to align the object shape
++        // with the spec.
++        // (configurable = false, enumerable = true, writable = false)
++        Object.freeze(this.prototype)
++        Object.freeze(this)
++
++        attacher.attach = (standard, ws) => {
++            if (standard.#ws) {
++                throw new Error("WebSocket already attached")
++            }
++            standard.#ws = ws
++            init(standard, ws)
++            return standard
++        }
++    }
++}
++
++function init(standard: WebSocket, ws: ws.WebSocket) {
++
++    // set the binary type to `"blob"` to align with the browser default
++    // @ts-expect-error `"blob"` is supported by `ws`
++    // https://github.com/websockets/ws/blob/8.18.0/lib/constants.js#L6
++    ws.binaryType = "blob"
++
++    if (ws.readyState === ws.OPEN) {
++        const event = new Event("open")
++        standard.onopen?.(event)
++        standard.dispatchEvent(event)
++    }
++
++    // The functions are not using the arrow syntax
++    // to allow the name to appear in stacktraces.
++    ws.on("open", function onOpen() {
++        const event = new Event("open")
++        standard.onopen?.(event)
++        standard.dispatchEvent(event)
++    })
++    ws.on("message", function onMessage(data, isBinary) {
++        const event = new MessageEvent("message", { data: isBinary ? data : data.toString(), })
++        standard.onmessage?.(event)
++        standard.dispatchEvent(event)
++    })
++    ws.on("error", function onError(error) {
++        const event = new ErrorEvent(error, error.message)
++        standard.onerror?.(event)
++        standard.dispatchEvent(event)
++    })
++    // Using `.addEventListener()` here instead of `.on()`,
++    // because the `wasClean` field is determined by ws's
++    // internals.
++    ws.addEventListener("close", function onClose(ev) {
++        /**
++         * The `CloseEvent` is available globally
++         * starting with Node.js 23. Use it if available.
++         * https://nodejs.org/api/globals.html#:~:text=The%20CloseEvent%20class
++         */
++        const event = new (globalThis.CloseEvent ?? CloseEvent)("close", ev)
++        standard.onclose?.(event)
++        standard.dispatchEvent(event)
++    })
++}
++
++// `ErrorEvent` does not exist in browsers. The "error"
++// event is an instance of `Error`, but on the server,
++// there is more information available about the exact
++// error, which is exposed via this subclass.
++export class ErrorEvent extends Event {
++    constructor(readonly error: Error, readonly message: string) {
++        super("error")
++    }
++}
++
++export class CloseEvent extends Event implements globalThis.CloseEvent {
++    readonly code: number
++    readonly reason: string
++    readonly wasClean: boolean
++
++    constructor(type: string, eventInitDict: CloseEventInit) {
++        super(type, eventInitDict)
++        this.code = eventInitDict.code ?? 0
++        this.reason = eventInitDict.reason ?? ""
++        this.wasClean = eventInitDict.wasClean ?? false
++    }
++}
+-- 
+2.47.0.windows.2
+

--- a/packages/cloudflare-websocket/0002-use-implementation.patch
+++ b/packages/cloudflare-websocket/0002-use-implementation.patch
@@ -1,4 +1,4 @@
-From 7951f599557f7f5415893c68ecd8b43db9af9109 Mon Sep 17 00:00:00 2001
+From 2a6cbac46ca012c238f0af507b09f700e4c8da3b Mon Sep 17 00:00:00 2001
 From: Arsh <69170106+lilnasy@users.noreply.github.com>
 Date: Sun, 22 Dec 2024 01:42:33 +0530
 Subject: [PATCH 2/3] use implementation
@@ -9,7 +9,7 @@ Subject: [PATCH 2/3] use implementation
  2 files changed, 108 insertions(+), 2 deletions(-)
 
 diff --git a/packages/cloudflare/src/entrypoints/server.ts b/packages/cloudflare/src/entrypoints/server.ts
-index 0ccc39e2..ad03ec90 100644
+index 0ccc39e2..2f591c92 100644
 --- a/packages/cloudflare/src/entrypoints/server.ts
 +++ b/packages/cloudflare/src/entrypoints/server.ts
 @@ -7,6 +7,7 @@ import type { SSRManifest } from 'astro';
@@ -27,7 +27,7 @@ index 0ccc39e2..ad03ec90 100644
 +/**
 + * Cloudflare workers do not fire the open event. This results
 + * in interop issues with the other runtimes.
-+ * 
++ *
 + * The server websocket is tracked in this so that - when the
 + * corresponding response is returned - the open event can be
 + * dispatched on it.

--- a/packages/cloudflare-websocket/0002-use-implementation.patch
+++ b/packages/cloudflare-websocket/0002-use-implementation.patch
@@ -1,15 +1,15 @@
-From e81d06d0cbc245207705c5bbae39bac9badf45d8 Mon Sep 17 00:00:00 2001
+From 7951f599557f7f5415893c68ecd8b43db9af9109 Mon Sep 17 00:00:00 2001
 From: Arsh <69170106+lilnasy@users.noreply.github.com>
 Date: Sun, 22 Dec 2024 01:42:33 +0530
 Subject: [PATCH 2/3] use implementation
 
 ---
- packages/cloudflare/src/entrypoints/server.ts | 38 ++++++++++++-
- packages/cloudflare/src/index.ts              | 57 ++++++++++++++++++-
- 2 files changed, 93 insertions(+), 2 deletions(-)
+ packages/cloudflare/src/entrypoints/server.ts | 47 +++++++++++++-
+ packages/cloudflare/src/index.ts              | 63 ++++++++++++++++++-
+ 2 files changed, 108 insertions(+), 2 deletions(-)
 
 diff --git a/packages/cloudflare/src/entrypoints/server.ts b/packages/cloudflare/src/entrypoints/server.ts
-index 0ccc39e2..fc8e6306 100644
+index 0ccc39e2..ad03ec90 100644
 --- a/packages/cloudflare/src/entrypoints/server.ts
 +++ b/packages/cloudflare/src/entrypoints/server.ts
 @@ -7,6 +7,7 @@ import type { SSRManifest } from 'astro';
@@ -70,12 +70,21 @@ index 0ccc39e2..fc8e6306 100644
  				ctx: {
  					waitUntil: (promise: Promise<any>) => context.waitUntil(promise),
  					// Currently not available: https://developers.cloudflare.com/pages/platform/known-issues/#pages-functions
-@@ -82,6 +113,11 @@ export function createExports(manifest: SSRManifest) {
+@@ -82,6 +113,20 @@ export function createExports(manifest: SSRManifest) {
  
  		const response = await app.render(request, { routeData, locals });
  
 +		const socket = responseToSocketMap.get(response)
 +		if (socket) {
++			// @ts-expect-error Cloudflare's extends WebSocket with an accept
++			// method that must be called before the socket can be used.
++			// In our API, returning the upgrade response from an API route
++			// or the page implies accepting the WebSocket connection.
++			socket.accept()
++			// @ts-expect-error This listener should exist to avoid
++			// "script will never generate a response" errors, but for some
++			// reason, they happen anyway in workerd.
++			socket.addEventListener("close", e => e.currentTarget.close())
 +			socket.dispatchEvent(new Event("open"))
 +		}
 +
@@ -83,7 +92,7 @@ index 0ccc39e2..fc8e6306 100644
  			for (const setCookieHeader of app.setCookieHeaders(response)) {
  				response.headers.append('Set-Cookie', setCookieHeader);
 diff --git a/packages/cloudflare/src/index.ts b/packages/cloudflare/src/index.ts
-index c69cfbc7..c1a5b249 100644
+index c69cfbc7..26af5003 100644
 --- a/packages/cloudflare/src/index.ts
 +++ b/packages/cloudflare/src/index.ts
 @@ -5,7 +5,7 @@ import type {
@@ -167,7 +176,20 @@ index c69cfbc7..c1a5b249 100644
  	return {
  		name: '@astrojs/cloudflare',
  		hooks: {
-@@ -206,6 +257,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
+@@ -170,6 +221,12 @@ export default function createIntegration(args?: Options): AstroIntegration {
+ 					entrypoint: '@astrojs/cloudflare/entrypoints/middleware.js',
+ 					order: 'pre',
+ 				});
++				if (command === "dev") {
++					addMiddleware({
++						entrypoint: new URL("./websocket/dev-middleware.ts", import.meta.url),
++						order: "pre"
++					})
++				}
+ 			},
+ 			'astro:routes:resolved': ({ routes }) => {
+ 				_routes = routes;
+@@ -206,6 +263,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
  				});
  			},
  			'astro:server:setup': async ({ server }) => {
@@ -175,7 +197,7 @@ index c69cfbc7..c1a5b249 100644
  				if ((args?.platformProxy?.enabled ?? true) === true) {
  					const platformProxy = await getPlatformProxy(args?.platformProxy);
  
-@@ -234,6 +286,9 @@ export default function createIntegration(args?: Options): AstroIntegration {
+@@ -234,6 +292,9 @@ export default function createIntegration(args?: Options): AstroIntegration {
  					});
  				}
  			},

--- a/packages/cloudflare-websocket/0002-use-implementation.patch
+++ b/packages/cloudflare-websocket/0002-use-implementation.patch
@@ -1,0 +1,190 @@
+From e81d06d0cbc245207705c5bbae39bac9badf45d8 Mon Sep 17 00:00:00 2001
+From: Arsh <69170106+lilnasy@users.noreply.github.com>
+Date: Sun, 22 Dec 2024 01:42:33 +0530
+Subject: [PATCH 2/3] use implementation
+
+---
+ packages/cloudflare/src/entrypoints/server.ts | 38 ++++++++++++-
+ packages/cloudflare/src/index.ts              | 57 ++++++++++++++++++-
+ 2 files changed, 93 insertions(+), 2 deletions(-)
+
+diff --git a/packages/cloudflare/src/entrypoints/server.ts b/packages/cloudflare/src/entrypoints/server.ts
+index 0ccc39e2..fc8e6306 100644
+--- a/packages/cloudflare/src/entrypoints/server.ts
++++ b/packages/cloudflare/src/entrypoints/server.ts
+@@ -7,6 +7,7 @@ import type { SSRManifest } from 'astro';
+ import { App } from 'astro/app';
+ import { setGetEnv } from 'astro/env/setup';
+ import { createGetEnv } from '../utils/env.js';
++import type { Locals } from '../index.js';
+ 
+ type Env = {
+ 	[key: string]: unknown;
+@@ -23,6 +24,16 @@ export interface Runtime<T extends object = object> {
+ 	};
+ }
+ 
++/**
++ * Cloudflare workers do not fire the open event. This results
++ * in interop issues with the other runtimes.
++ * 
++ * The server websocket is tracked in this so that - when the
++ * corresponding response is returned - the open event can be
++ * dispatched on it.
++ */
++const responseToSocketMap = new WeakMap<Response, WebSocket>()
++
+ export function createExports(manifest: SSRManifest) {
+ 	const app = new App(manifest);
+ 
+@@ -61,11 +72,31 @@ export function createExports(manifest: SSRManifest) {
+ 			}
+ 		})();
+ 
+-		const locals: Runtime = {
++		const locals: Runtime & Locals = {
++			get isUpgradeRequest() {
++				return request.headers.get("upgrade") === "websocket"
++			},
++
++			upgradeWebSocket() {
++				// @ts-expect-error modifiers can appear here
++				declare const WebSocketPair: typeof import('@cloudflare/workers-types').WebSocketPair
++				const { 0: clientWs, 1: serverWs } = new WebSocketPair
++				const response = new Response(null, {
++					status: 101,
++					// @ts-expect-error Cloudflare extends Response with a webSocket property
++					webSocket: clientWs,
++				})
++				// @ts-expect-error Cloudflare's WebSocket is missing a few properties from the
++				// browser's WebSocket interface
++				const socket: WebSocket = serverWs
++				responseToSocketMap.set(response, socket)
++				return { response, socket };
++			},
+ 			runtime: {
+ 				env: env,
+ 				cf: request.cf,
+ 				caches: caches as unknown as CLOUDFLARE_CACHESTORAGE,
++				// @ts-ignore
+ 				ctx: {
+ 					waitUntil: (promise: Promise<any>) => context.waitUntil(promise),
+ 					// Currently not available: https://developers.cloudflare.com/pages/platform/known-issues/#pages-functions
+@@ -82,6 +113,11 @@ export function createExports(manifest: SSRManifest) {
+ 
+ 		const response = await app.render(request, { routeData, locals });
+ 
++		const socket = responseToSocketMap.get(response)
++		if (socket) {
++			socket.dispatchEvent(new Event("open"))
++		}
++
+ 		if (app.setCookieHeaders) {
+ 			for (const setCookieHeader of app.setCookieHeaders(response)) {
+ 				response.headers.append('Set-Cookie', setCookieHeader);
+diff --git a/packages/cloudflare/src/index.ts b/packages/cloudflare/src/index.ts
+index c69cfbc7..c1a5b249 100644
+--- a/packages/cloudflare/src/index.ts
++++ b/packages/cloudflare/src/index.ts
+@@ -5,7 +5,7 @@ import type {
+ 	IntegrationResolvedRoute,
+ 	IntegrationRouteData,
+ } from 'astro';
+-import type { PluginOption } from 'vite';
++import type { PluginOption, ViteDevServer } from 'vite';
+ 
+ import { createReadStream } from 'node:fs';
+ import { appendFile, rename, stat } from 'node:fs/promises';
+@@ -26,6 +26,7 @@ import {
+ import { createGetEnv } from './utils/env.js';
+ import { createRoutesFile, getParts } from './utils/generate-routes-json.js';
+ import { setImageConfig } from './utils/image-config.js';
++import { handleUpgradeRequests } from './websocket/dev-middleware.js';
+ 
+ export type { Runtime } from './entrypoints/server.js';
+ 
+@@ -74,6 +75,54 @@ export type Options = {
+ 	cloudflareModules?: boolean;
+ };
+ 
++
++export interface Locals {
++	/**
++	 * Whether the current request wants the connection to be upgraded
++	 * to a WebSocket.
++	 */
++    isUpgradeRequest: boolean
++    /**
++     * Upgrade an incoming HTTP request to a bidirectional WebSocket
++     * connection.
++     *
++     * Returns a pair of {@linkcode WebSocket} and {@linkcode Response}
++     * instances. The request must be responded to with the provided
++     * response for the provided WebSocket to open and start receiving
++     * messages from the browser.
++     *
++     * ```ts
++     * export const GET: APIRoute = ctx => {
++     *     if (ctx.locals.isUpgradeRequest) {
++     *         const { response, socket } = ctx.locals.upgradeWebSocket()
++     *         socket.onmessage = event => {
++     *             if (event.data === "ping") {
++     *                 socket.send("pong")
++     *             }
++     *         }
++     *         return response
++     *     }
++     *     return new Response("Upgrade required", { status: 426 })
++     * }
++     * ```
++     *
++     * Calling this function on its own does not connect the WebSocket.
++     * It only returns a pair of objects that will establish the connection
++     * once the generated response has been returned from the API Route.
++     *
++     * Throws if the request is not an upgrade request.
++     */
++    upgradeWebSocket(): { socket: WebSocket, response: Response };
++}
++
++interface NodeLocals extends Locals {}
++
++declare global {
++	namespace App {
++		export interface Locals extends NodeLocals {}
++	}
++}
++
+ function wrapWithSlashes(path: string): string {
+ 	return prependForwardSlash(appendForwardSlash(path));
+ }
+@@ -122,6 +171,8 @@ export default function createIntegration(args?: Options): AstroIntegration {
+ 
+ 	let _routes: IntegrationResolvedRoute[];
+ 
++	let viteDevServer: ViteDevServer;
++
+ 	return {
+ 		name: '@astrojs/cloudflare',
+ 		hooks: {
+@@ -206,6 +257,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
+ 				});
+ 			},
+ 			'astro:server:setup': async ({ server }) => {
++				viteDevServer = server;
+ 				if ((args?.platformProxy?.enabled ?? true) === true) {
+ 					const platformProxy = await getPlatformProxy(args?.platformProxy);
+ 
+@@ -234,6 +286,9 @@ export default function createIntegration(args?: Options): AstroIntegration {
+ 					});
+ 				}
+ 			},
++			"astro:server:start" () {
++				handleUpgradeRequests(viteDevServer)
++			},
+ 			'astro:build:setup': ({ vite, target }) => {
+ 				if (target === 'server') {
+ 					vite.resolve ||= {};
+-- 
+2.47.0.windows.2
+

--- a/packages/cloudflare-websocket/0003-adjust-package.patch
+++ b/packages/cloudflare-websocket/0003-adjust-package.patch
@@ -1,0 +1,83 @@
+From 16b9265a1e248c7769f5d2fc7291b640754fdbc5 Mon Sep 17 00:00:00 2001
+From: Arsh <69170106+lilnasy@users.noreply.github.com>
+Date: Sun, 22 Dec 2024 01:52:33 +0530
+Subject: [PATCH 3/3] adjust package
+
+---
+ packages/cloudflare/src/index.ts              | 10 +++++-----
+ packages/cloudflare/src/utils/image-config.ts |  5 +++--
+ 2 files changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/packages/cloudflare/src/index.ts b/packages/cloudflare/src/index.ts
+index c1a5b249..855e9e6d 100644
+--- a/packages/cloudflare/src/index.ts
++++ b/packages/cloudflare/src/index.ts
+@@ -174,7 +174,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
+ 	let viteDevServer: ViteDevServer;
+ 
+ 	return {
+-		name: '@astrojs/cloudflare',
++		name: "astro-cloudflare-websocket",
+ 		hooks: {
+ 			'astro:config:setup': ({
+ 				command,
+@@ -218,7 +218,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
+ 					addWatchFile(new URL('./wrangler.jsonc', config.root));
+ 				}
+ 				addMiddleware({
+-					entrypoint: '@astrojs/cloudflare/entrypoints/middleware.js',
++					entrypoint: new URL("./entrypoints/middleware.ts", import.meta.url),
+ 					order: 'pre',
+ 				});
+ 			},
+@@ -228,15 +228,15 @@ export default function createIntegration(args?: Options): AstroIntegration {
+ 			'astro:config:done': ({ setAdapter, config, buildOutput, logger }) => {
+ 				if (buildOutput === 'static') {
+ 					logger.warn(
+-						'[@astrojs/cloudflare] This adapter is intended to be used with server rendered pages, which this project does not contain any of. As such, this adapter is unnecessary.'
++						'This adapter is intended to be used with server rendered pages, which this project does not contain any of. As such, this adapter is unnecessary.'
+ 					);
+ 				}
+ 
+ 				_config = config;
+ 
+ 				setAdapter({
+-					name: '@astrojs/cloudflare',
+-					serverEntrypoint: '@astrojs/cloudflare/entrypoints/server.js',
++					name: "astro-cloudflare-websocket",
++					serverEntrypoint: new URL("./entrypoints/server.ts", import.meta.url),
+ 					exports: ['default'],
+ 					adapterFeatures: {
+ 						edgeMiddleware: false,
+diff --git a/packages/cloudflare/src/utils/image-config.ts b/packages/cloudflare/src/utils/image-config.ts
+index 58e0f76a..6b18b8b9 100644
+--- a/packages/cloudflare/src/utils/image-config.ts
++++ b/packages/cloudflare/src/utils/image-config.ts
+@@ -1,5 +1,6 @@
+ import type { AstroConfig, AstroIntegrationLogger, HookParameters } from 'astro';
+ import { passthroughImageService, sharpImageService } from 'astro/config';
++import { fileURLToPath } from "node:url"
+ 
+ export function setImageConfig(
+ 	service: string,
+@@ -17,7 +18,7 @@ export function setImageConfig(
+ 				service:
+ 					command === 'dev'
+ 						? sharpImageService()
+-						: { entrypoint: '@astrojs/cloudflare/image-service' },
++						: { entrypoint: fileURLToPath(new URL('../entrypoints/image-service.ts', import.meta.url)) },
+ 			};
+ 
+ 		case 'compile':
+@@ -25,7 +26,7 @@ export function setImageConfig(
+ 				...config,
+ 				service: sharpImageService(),
+ 				endpoint: {
+-					entrypoint: command === 'dev' ? undefined : '@astrojs/cloudflare/image-endpoint',
++					entrypoint: command === 'dev' ? undefined : fileURLToPath(new URL('../entrypoints/image-endpoint.ts', import.meta.url)),
+ 				},
+ 			};
+ 
+-- 
+2.47.0.windows.2
+

--- a/packages/cloudflare-websocket/0003-adjust-package.patch
+++ b/packages/cloudflare-websocket/0003-adjust-package.patch
@@ -1,4 +1,4 @@
-From 16b9265a1e248c7769f5d2fc7291b640754fdbc5 Mon Sep 17 00:00:00 2001
+From 15acaf09f79c018e2e9e61f2be7eb4aeefc9a47c Mon Sep 17 00:00:00 2001
 From: Arsh <69170106+lilnasy@users.noreply.github.com>
 Date: Sun, 22 Dec 2024 01:52:33 +0530
 Subject: [PATCH 3/3] adjust package
@@ -9,7 +9,7 @@ Subject: [PATCH 3/3] adjust package
  2 files changed, 8 insertions(+), 7 deletions(-)
 
 diff --git a/packages/cloudflare/src/index.ts b/packages/cloudflare/src/index.ts
-index c1a5b249..855e9e6d 100644
+index 26af5003..71065495 100644
 --- a/packages/cloudflare/src/index.ts
 +++ b/packages/cloudflare/src/index.ts
 @@ -174,7 +174,7 @@ export default function createIntegration(args?: Options): AstroIntegration {
@@ -29,8 +29,8 @@ index c1a5b249..855e9e6d 100644
 +					entrypoint: new URL("./entrypoints/middleware.ts", import.meta.url),
  					order: 'pre',
  				});
- 			},
-@@ -228,15 +228,15 @@ export default function createIntegration(args?: Options): AstroIntegration {
+ 				if (command === "dev") {
+@@ -234,15 +234,15 @@ export default function createIntegration(args?: Options): AstroIntegration {
  			'astro:config:done': ({ setAdapter, config, buildOutput, logger }) => {
  				if (buildOutput === 'static') {
  					logger.warn(

--- a/packages/cloudflare-websocket/0003-adjust-package.patch
+++ b/packages/cloudflare-websocket/0003-adjust-package.patch
@@ -1,4 +1,4 @@
-From 15acaf09f79c018e2e9e61f2be7eb4aeefc9a47c Mon Sep 17 00:00:00 2001
+From b0fa80443b5a61cd85dd3807bb66cadef503b620 Mon Sep 17 00:00:00 2001
 From: Arsh <69170106+lilnasy@users.noreply.github.com>
 Date: Sun, 22 Dec 2024 01:52:33 +0530
 Subject: [PATCH 3/3] adjust package

--- a/packages/cloudflare-websocket/README.md
+++ b/packages/cloudflare-websocket/README.md
@@ -1,0 +1,167 @@
+# astro-cloudflare-websocket 🔌
+
+This **[Astro integration][astro-integration]** provides an adapter for Astro that allows you to host SSG and SSR sites on [Cloudflare Workers](https://workers.cloudflare.com/), with realtime features using WebSocket.
+
+- <strong>[Why astro-cloudflare-websocket?](#why-astro-cloudflare-websocket)</strong>
+- <strong>[Installation](#installation)</strong>
+- <strong>[Usage](#usage)</strong>
+- <strong>[Troubleshooting](#troubleshooting)</strong>
+- <strong>[Contributing](#contributing)</strong>
+- <strong>[Changelog](#changelog)</strong>
+
+## Why astro-cloudflare-websocket?
+
+The `astro-cloudflare-websocket` integration allows you to handle WebSocket connections in your Astro project and deploy it on [Cloudflare Workers](https://workers.cloudflare.com/), with realtime features. You no longer need to maintain a separate WebSocket server and complicated build processes to add realtime features. You can handle WebSocket requests directly in your API Routes, middleware, and even in the frontmatter of your Astro pages!
+
+As a fork of the official [`@astrojs/cloudflare`](https://docs.astro.build/en/guides/integrations-guide/cloudflare/) adapter, it provides the same configuration options, and remains backwards compatible with its features and behavior.
+
+## Installation
+
+### Manual Install
+
+First, install the `astro-cloudflare-websocket` package using your package manager. If you're using npm or aren't sure, run this in the terminal:
+
+```sh
+npm install astro-cloudflare-websocket
+```
+
+Then, add this integration to your `astro.config.*` file using the [`adapter`](https://docs.astro.build/en/reference/configuration-reference/#adapter) property:
+
+```diff lang="js" "cloudflareWebSocket()"
+    // astro.config.mjs
+    import { defineConfig } from "astro/config"
+-    import cloudflare from "@astrojs/cloudflare"
++    import cloudflareWebSocket from "astro-cloudflare-websocket"
+
+    export default defineConfig({
+        // ...
+-        adapter: cloudflare()
++        adapter: cloudflareWebSocket(),
+        // ...
+    });
+```
+
+## Usage
+
+The integration adds an `upgradeWebSocket()` method to the [`context.locals`](https://docs.astro.build/en/guides/middleware/#storing-data-in-contextlocals) object. This method returns an object with `response` and `socket` fields.
+
+```ts
+// src/pages/api/socket.ts
+export const GET: APIRoute = ctx => {
+    if (ctx.request.headers.get("upgrade") === "websocket") {
+        const { response, socket } = ctx.locals.upgradeWebSocket()
+        socket.addEventListener("message", event => {
+            if (event.data === "ping") {
+                socket.send("pong")
+            }
+        })
+        return response
+    }
+    return new Response("Upgrade required", { status: 426 })
+}
+```
+
+The `response` field provides a `Response` object that you can return to accept the WebSocket upgrade request. The `socket` field is a `WebSocket` object, which allows you to send messages to the browser and receive messages from it. This API of the `WebSocket` is fully compatible with the browser's [`WebSocket API`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), so you can program the server WebSocket in the same way you would program the browser WebSocket.
+
+Note that this integration does not require any special client-side WebSocket library, you can use the native `WebSocket` API in the browser. Here is an example of the client-side code that connects to the above server WebSocket:
+
+```astro
+---
+// src/pages/index.astro
+---
+<script>
+    const socket = new WebSocket(`${location.origin}/api/socket`)
+    socket onopen = event => {
+        socket.send("ping")
+    }
+    socket.onmessage = event => {
+        console.log(event.data)
+    }
+</script>
+```
+
+To simplify the detection of whether a request can be upgraded to a WebSocket connection, the adapter also adds `locals.isUpgradeRequest` to the context. This value is `true` if the request can be upgraded to a WebSocket connection, and `false` otherwise.
+
+```diff lang="ts"
+- if (ctx.request.headers.get("upgrade") === "websocket") { ... }
++ if (ctx.locals.isUpgradeRequest) { ... }
+```
+
+### Authorizing and rejecting requests
+
+If the endpoint returns any response other than the one provided by `upgradeWebSocket()`, the upgrade request will be rejected, and a WebSocket connection will not be established. This enables you to easily implement authorization logic or other checks before accepting the upgrade request.
+
+For example, the following code shows how you would check for the presence of a cookie:
+
+```ts
+// src/pages/api/socket.ts
+export const GET: APIRoute = ctx => {
+    const cookie = ctx.cookies.get("xyz")
+    if (!cookie) {
+        return new Response("Unauthorized", { status: 401 })
+    }
+    if (!ctx.locals.isUpgradeRequest) {
+        return new Response("Upgrade Required", { status: 426 })
+    }
+    const { response, socket } = ctx.locals.upgradeWebSocket()
+    handleWebSocket(socket)
+    return response
+}
+```
+
+When a `WebSocket` connection fails to establish, browsers do not provide specific information in the `error` event about the cause. A `WebSocket` connection can close "cleanly" if it was successfully established and then intentionally closed. Alternatively, it can close non-cleanly if the server becomes unreachable due to network issues or if the connection could not be established in the first place. See the MDN documentation for more information: [CloseEvent: wasClean property - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/wasClean).
+
+## Troubleshooting
+
+### Error: "The request must be an upgrade request to upgrade the connection to a WebSocket."
+
+This error occurs when a connection upgrade attempt is made using `locals.upgradeWebSocket()` on a request that does not have the necessary headers.
+
+On the server, verify that the request is an upgrade request by checking `locals.isUpgradeRequest` before calling `locals.upgradeWebSocket()`.
+
+It is important to know that in the browser, the `fetch` API cannot be used to send an upgrade request. Make sure that you are instantiating the built-in `WebSocket` class. See examples on MDN: [WebSocket - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket#examples).
+
+
+For additional help, check out the `Discussions` tab on the [GitHub repo](https://github.com/lilnasy/gratelets/discussions).
+
+## Contributing
+
+This package is maintained by [lilnasy](https://github.com/lilnasy) independently from Astro.
+
+The code for this package is commited to the repository as a series of patches applied on top of the [`withastro/adapters`](https://github.com/withastro/adapters) repository, which is where the code for the `@astrojs/cloudflare` adapter is maintained. Additionally, the `withastro/adapters` repository is added as a git submodule to make it easier to update the patches. The [`package.json`](https://github.com/lilnasy/gratelets/blob/main/packages/cloudflare-websocket/package.json#L43-L47) file contains scripts to automatically manage the upstream repository and the patches.
+
+To introduce a change, make sure you're in `packages/cloudflare-websocket` directory:
+```bash
+../gratelets/ $ cd packages/cloudflare-websocket
+```
+Then, run the `load_patches` script using `pnpm` to clone the upstream repository and apply the patches:
+```bash
+../gratelets/packages/cloudflare-websocket/ $ pnpm run load_patches
+```
+Now, you can browse around the code by going into the `withastro/adapters` submodule:
+```bash
+../gratelets/packages/cloudflare-websocket/ $ cd withastro/adapters/packages/cloudflare
+../withastro/adapters/packages/cloudflare/ $ code .
+```
+Note that dependencies may need to separately be installed in the `withastro/adapters` submodule.
+```bash
+../withastro/adapters/packages/cloudflare/ $ pnpm install
+```
+After you've made the changes you want, you can commit them as normal. However, instead of pushing the changes, you would update the patches by running `create_patches` script using `pnpm`:
+```bash
+../gratelets/packages/cloudflare-websocket/ $ pnpm run create_patches
+```
+This will add and update patches present in `packages/cloudflare-websocket` with the changes you've made.
+
+Now, you can commit these patch files to the gratelets repository, and push.
+```bash
+../withastro/adapters/packages/cloudflare/ $ cd ../../../..
+../gratelets/packages/cloudflare-websocket/ $ git commit -m "fix bug"
+../gratelets/packages/cloudflare-websocket/ $ git push
+```
+
+## Changelog
+
+See [CHANGELOG.md](https://github.com/lilnasy/gratelets/blob/main/packages/cloudflare-websocket/CHANGELOG.md) for a history of changes to this integration.
+
+[astro-integration]: https://docs.astro.build/en/guides/integrations-guide/

--- a/packages/cloudflare-websocket/package.json
+++ b/packages/cloudflare-websocket/package.json
@@ -1,0 +1,49 @@
+{
+    "name": "astro-cloudflare-websocket",
+    "type": "module",
+    "description": "Use WebSockets in your Astro SSR Apps and run it on Cloudflare Workers.",
+    "version": "0.0.0",
+    "license": "MIT",
+    "keywords": [
+        "withastro",
+        "astro",
+        "astro-integration",
+        "astro-adapter",
+        "cloudflare",
+        "workers",
+        "websocket"
+    ],
+    "homepage": "https://github.com/lilnasy/gratelets/packages/cloudflare-websocket",
+    "files": [
+        "withastro/adapters/packages/cloudflare/src"
+    ],
+    "exports": {
+        ".": "./withastro/adapters/packages/cloudflare/src/index.ts",
+        "./websocket": {
+            "development": "./withastro/adapters/packages/cloudflare/src/websocket/dev-websocket.ts",
+            "production": "./withastro/adapters/packages/cloudflare/src/websocket/cloudflare-websocket.ts"
+        }
+    },
+    "dependencies": {
+        "@astrojs/internal-helpers": "0.4.1",
+        "@astrojs/underscore-redirects": "^0.4.0-alpha.0",
+        "@cloudflare/workers-types": "^4.20241112.0",
+        "@types/ws": "^8.5.13",
+        "esbuild": "^0.24.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.14",
+        "miniflare": "^3.20241106.1",
+        "tiny-glob": "^0.2.9",
+        "vite": "^6.0.2",
+        "wrangler": "^3.91.0",
+        "ws": "^8.18.0"
+    },
+    "scripts": {
+        "clone": "git submodule update --init .",
+        "create_patches": "cd withastro/adapters && git format-patch b2f9ef9 -o ../..",
+        "load_patches": "git submodule update --init . && cd withastro/adapters && git am ../../*.patch",
+        "delete_all_changes_and_unload_patches": "cd withastro/adapters && git reset --hard b2f9ef9",
+        "delete_all_changes_and_reload_patches": "cd withastro/adapters && git reset --hard b2f9ef9 && git am ../../*.patch",
+        "test": "pnpm -w test cloudflare-websocket.test.ts"
+    }
+}

--- a/packages/cloudflare-websocket/package.json
+++ b/packages/cloudflare-websocket/package.json
@@ -33,6 +33,7 @@
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.14",
         "miniflare": "^3.20241106.1",
+        "rollup": "^4.29.1",
         "tiny-glob": "^0.2.9",
         "vite": "^6.0.2",
         "wrangler": "^3.91.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,45 @@ importers:
         specifier: '20'
         version: 20.17.10
 
+  packages/cloudflare-websocket:
+    dependencies:
+      '@astrojs/internal-helpers':
+        specifier: 0.4.1
+        version: 0.4.1
+      '@astrojs/underscore-redirects':
+        specifier: ^0.4.0-alpha.0
+        version: 0.4.0
+      '@cloudflare/workers-types':
+        specifier: ^4.20241112.0
+        version: 4.20241218.0
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.5.13
+      esbuild:
+        specifier: ^0.24.0
+        version: 0.24.0
+      estree-walker:
+        specifier: ^3.0.3
+        version: 3.0.3
+      magic-string:
+        specifier: ^0.30.14
+        version: 0.30.17
+      miniflare:
+        specifier: ^3.20241106.1
+        version: 3.20241218.0(bufferutil@4.0.8)
+      tiny-glob:
+        specifier: ^0.2.9
+        version: 0.2.9
+      vite:
+        specifier: ^6.0.2
+        version: 6.0.5(@types/node@20.17.10)(jiti@2.4.2)
+      wrangler:
+        specifier: ^3.91.0
+        version: 3.99.0(@cloudflare/workers-types@4.20241218.0)(bufferutil@4.0.8)
+      ws:
+        specifier: ^8.18.0
+        version: 8.18.0(bufferutil@4.0.8)
+
   packages/deno-websocket:
     dependencies:
       '@types/lodash':
@@ -456,6 +495,9 @@ packages:
   '@astrojs/compiler@2.10.3':
     resolution: {integrity: sha512-bL/O7YBxsFt55YHU021oL+xz+B/9HvGNId3F9xURN16aeqDK9juHGktdkCSXz+U4nqFACq6ZFvWomOzhV+zfPw==}
 
+  '@astrojs/internal-helpers@0.4.1':
+    resolution: {integrity: sha512-bMf9jFihO8YP940uD70SI/RDzIhUHJAolWVcO1v5PUivxGKvfLZTLTVVxEYzGYyPsA3ivdLNqMnL5VgmQySa+g==}
+
   '@astrojs/internal-helpers@0.4.2':
     resolution: {integrity: sha512-EdDWkC3JJVcpGpqJAU/5hSk2LKXyG3mNGkzGoAuyK+xoPHbaVdSuIWoN1QTnmK3N/gGfaaAfM8gO2KDCAW7S3w==}
 
@@ -519,6 +561,9 @@ packages:
   '@astrojs/telemetry@3.2.0':
     resolution: {integrity: sha512-wxhSKRfKugLwLlr4OFfcqovk+LIFtKwLyGPqMsv+9/ibqqnW3Gv7tBhtKEb0gAyUAC4G9BTVQeQahqnQAhd6IQ==}
     engines: {node: ^18.17.1 || ^20.3.0 || >=22.0.0}
+
+  '@astrojs/underscore-redirects@0.4.0':
+    resolution: {integrity: sha512-Urt32++4ql0IFTTNejnRIN7LPJ6YzU9QXLcc4RXm5or1RLPnQBKVrLvmDxKx3eT72l7ZAi6W4L5E7pcbWbYDRA==}
 
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
@@ -690,6 +735,47 @@ packages:
   '@changesets/write@0.3.2':
     resolution: {integrity: sha512-kDxDrPNpUgsjDbWBvUo27PzKX4gqeKOlhibaOXDJA6kuBisGqNHv/HwGJrAu8U/dSf8ZEFIeHIPtvSlZI1kULw==}
 
+  '@cloudflare/kv-asset-handler@0.3.4':
+    resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
+    engines: {node: '>=16.13'}
+
+  '@cloudflare/workerd-darwin-64@1.20241218.0':
+    resolution: {integrity: sha512-8rveQoxtUvlmORKqTWgjv2ycM8uqWox0u9evn3zd2iWKdou5sncFwH517ZRLI3rq9P31ZLmCQBZ0gloFsTeY6w==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20241218.0':
+    resolution: {integrity: sha512-be59Ad9nmM9lCkhHqmTs/uZ3JVZt8NJ9Z0PY+B0xnc5z6WwmV2lj0RVLtq7xJhQsQJA189zt5rXqDP6J+2mu7Q==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20241218.0':
+    resolution: {integrity: sha512-MzpSBcfZXRxrYWxQ4pVDYDrUbkQuM62ssl4ZtHH8J35OAeGsWFAYji6MkS2SpVwVcvacPwJXIF4JSzp4xKImKw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20241218.0':
+    resolution: {integrity: sha512-RIuJjPxpNqvwIs52vQsXeRMttvhIjgg9NLjjFa3jK8Ijnj8c3ZDru9Wqi48lJP07yDFIRr4uDMMqh/y29YQi2A==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20241218.0':
+    resolution: {integrity: sha512-tO1VjlvK3F6Yb2d1jgEy/QBYl//9Pyv3K0j+lq8Eu7qdfm0IgKwSRgDWLept84/qmNsQfausZ4JdNGxTf9xsxQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20241218.0':
+    resolution: {integrity: sha512-Y0brjmJHcAZBXOPI7lU5hbiXglQWniA1kQjot2ata+HFimyjPPcz+4QWBRrmWcMPo0OadR2Vmac7WStDLpvz0w==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@emnapi/runtime@1.3.1':
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
 
@@ -723,6 +809,16 @@ packages:
   '@emotion/weak-memoize@0.4.0':
     resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
 
+  '@esbuild-plugins/node-globals-polyfill@0.2.3':
+    resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
+    peerDependencies:
+      esbuild: '*'
+
+  '@esbuild-plugins/node-modules-polyfill@0.2.2':
+    resolution: {integrity: sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==}
+    peerDependencies:
+      esbuild: '*'
+
   '@esbuild/aix-ppc64@0.19.12':
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
     engines: {node: '>=12'}
@@ -741,6 +837,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.17.19':
+    resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.19.12':
     resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
     engines: {node: '>=12'}
@@ -757,6 +859,12 @@ packages:
     resolution: {integrity: sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.17.19':
+    resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.19.12':
@@ -777,6 +885,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.17.19':
+    resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.19.12':
     resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
     engines: {node: '>=12'}
@@ -795,6 +909,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.17.19':
+    resolution: {integrity: sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.19.12':
     resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
     engines: {node: '>=12'}
@@ -811,6 +931,12 @@ packages:
     resolution: {integrity: sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.17.19':
+    resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.19.12':
@@ -831,6 +957,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.17.19':
+    resolution: {integrity: sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.19.12':
     resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
     engines: {node: '>=12'}
@@ -847,6 +979,12 @@ packages:
     resolution: {integrity: sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.17.19':
+    resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.19.12':
@@ -867,6 +1005,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.17.19':
+    resolution: {integrity: sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.19.12':
     resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
     engines: {node: '>=12'}
@@ -883,6 +1027,12 @@ packages:
     resolution: {integrity: sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.17.19':
+    resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.19.12':
@@ -903,6 +1053,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.17.19':
+    resolution: {integrity: sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.19.12':
     resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
     engines: {node: '>=12'}
@@ -919,6 +1075,12 @@ packages:
     resolution: {integrity: sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.17.19':
+    resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.19.12':
@@ -939,6 +1101,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.17.19':
+    resolution: {integrity: sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.19.12':
     resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
     engines: {node: '>=12'}
@@ -955,6 +1123,12 @@ packages:
     resolution: {integrity: sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.17.19':
+    resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.19.12':
@@ -975,6 +1149,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.17.19':
+    resolution: {integrity: sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.19.12':
     resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
     engines: {node: '>=12'}
@@ -991,6 +1171,12 @@ packages:
     resolution: {integrity: sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.17.19':
+    resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.19.12':
@@ -1011,6 +1197,12 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.17.19':
+    resolution: {integrity: sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.19.12':
     resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
     engines: {node: '>=12'}
@@ -1028,6 +1220,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
+
+  '@esbuild/netbsd-x64@0.17.19':
+    resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
 
   '@esbuild/netbsd-x64@0.19.12':
     resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
@@ -1053,6 +1251,12 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.17.19':
+    resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.19.12':
     resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
     engines: {node: '>=12'}
@@ -1070,6 +1274,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
+
+  '@esbuild/sunos-x64@0.17.19':
+    resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.19.12':
     resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
@@ -1089,6 +1299,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.17.19':
+    resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.19.12':
     resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
     engines: {node: '>=12'}
@@ -1105,6 +1321,12 @@ packages:
     resolution: {integrity: sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.17.19':
+    resolution: {integrity: sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.19.12':
@@ -1125,6 +1347,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-x64@0.17.19':
+    resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.19.12':
     resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
     engines: {node: '>=12'}
@@ -1142,6 +1370,10 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -1265,6 +1497,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -1615,6 +1850,9 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
+  '@types/node-forge@1.3.11':
+    resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -1747,6 +1985,9 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  as-table@1.0.55:
+    resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1806,6 +2047,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -1840,6 +2084,9 @@ packages:
 
   caniuse-lite@1.0.30001690:
     resolution: {integrity: sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==}
+
+  capnp-ts@0.7.0:
+    resolution: {integrity: sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1881,6 +2128,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -1977,8 +2228,14 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
+  data-uri-to-buffer@2.0.2:
+    resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
+
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
@@ -2118,6 +2375,11 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild@0.17.19:
+    resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.19.12:
     resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
     engines: {node: '>=12'}
@@ -2177,6 +2439,9 @@ packages:
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
+  estree-walker@0.6.1:
+    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -2193,6 +2458,10 @@ packages:
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
+
+  exit-hook@2.2.1:
+    resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
+    engines: {node: '>=6'}
 
   expect-type@1.1.0:
     resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
@@ -2273,6 +2542,9 @@ packages:
   get-port-please@3.1.2:
     resolution: {integrity: sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ==}
 
+  get-source@2.0.12:
+    resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
+
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
@@ -2284,9 +2556,15 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
+
+  globalyzer@0.1.0:
+    resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
 
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -2295,6 +2573,9 @@ packages:
   globby@14.0.2:
     resolution: {integrity: sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==}
     engines: {node: '>=18'}
+
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -2492,6 +2773,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  itty-time@1.0.6:
+    resolution: {integrity: sha512-+P8IZaLLBtFv8hCkIjcymZOp4UJ+xW6bSlQsXGqrkmJh7vSiMFSlNne0mCYagEE0N7HDNR5jJBRxwN0oYv61Rw==}
+
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
@@ -2576,6 +2860,9 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.25.9:
+    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -2782,6 +3069,11 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
+  miniflare@3.20241218.0:
+    resolution: {integrity: sha512-spYFDArH0wd+wJSTrzBrWrXJrbyJhRMJa35mat947y1jYhVV8I5V8vnD3LwjfpLr0SaEilojz1OIW7ekmnRe+w==}
+    engines: {node: '>=16.13'}
+    hasBin: true
+
   mlly@1.7.3:
     resolution: {integrity: sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==}
 
@@ -2795,6 +3087,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
 
   nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
@@ -2948,6 +3244,9 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -3019,6 +3318,9 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  printable-characters@1.0.42:
+    resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
+
   prismjs@1.29.0:
     resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
     engines: {node: '>=6'}
@@ -3060,6 +3362,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  readdirp@4.0.2:
+    resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
+    engines: {node: '>= 14.16.0'}
 
   recast@0.23.9:
     resolution: {integrity: sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==}
@@ -3152,6 +3458,16 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rollup-plugin-inject@3.0.2:
+    resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
+    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
+
+  rollup-plugin-node-polyfills@0.2.1:
+    resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
+
+  rollup-pluginutils@2.8.2:
+    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
+
   rollup@4.29.1:
     resolution: {integrity: sha512-RaJ45M/kmJUzSWDs1Nnd5DdV4eerC98idtUOVr6FfKcgxqvjwHmxc5upLF9qZU9EpsVzzhleFahrT3shLuJzIw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -3165,6 +3481,10 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  selfsigned@2.4.1:
+    resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
+    engines: {node: '>=10'}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3255,6 +3575,10 @@ packages:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
 
+  sourcemap-codec@1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
+
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
@@ -3271,12 +3595,19 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stacktracey@2.1.8:
+    resolution: {integrity: sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
 
   std-env@3.8.0:
     resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
+
+  stoppable@1.1.0:
+    resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
+    engines: {node: '>=4', npm: '>=6'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -3338,6 +3669,9 @@ packages:
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  tiny-glob@0.2.9:
+    resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -3414,6 +3748,13 @@ packages:
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  undici@5.28.4:
+    resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
+    engines: {node: '>=14.0'}
+
+  unenv-nightly@2.0.0-20241204-140205-a5d5190:
+    resolution: {integrity: sha512-jpmAytLeiiW01pl5bhVn9wYJ4vtiLdhGe10oXlJBuQEX8mxjxO8BlEXGHU4vr4yEikjFP1wsomTHt/CLU8kUwg==}
 
   unenv@1.10.0:
     resolution: {integrity: sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==}
@@ -3697,6 +4038,21 @@ packages:
     resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
     engines: {node: '>=18'}
 
+  workerd@1.20241218.0:
+    resolution: {integrity: sha512-7Z3D4vOVChMz9mWDffE299oQxUWm/pbkeAWx1btVamPcAK/2IuoNBhwflWo3jyuKuxvYuFAdIucgYxc8ICqXiA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@3.99.0:
+    resolution: {integrity: sha512-k0x4rT3G/QCbxcoZY7CHRVlAIS8WMmKdga6lf4d2c3gXFqssh44vwlTDuARA9QANBxKJTcA7JPTJRfUDhd9QBA==}
+    engines: {node: '>=16.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20241218.0
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@9.0.0:
     resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
     engines: {node: '>=18'}
@@ -3739,6 +4095,9 @@ packages:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
+  youch@3.3.4:
+    resolution: {integrity: sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==}
+
   zimmerframe@1.1.2:
     resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
 
@@ -3767,6 +4126,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
 
   '@astrojs/compiler@2.10.3': {}
+
+  '@astrojs/internal-helpers@0.4.1': {}
 
   '@astrojs/internal-helpers@0.4.2': {}
 
@@ -3948,6 +4309,8 @@ snapshots:
       which-pm-runs: 1.1.0
     transitivePeerDependencies:
       - supports-color
+
+  '@astrojs/underscore-redirects@0.4.0': {}
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -4251,6 +4614,31 @@ snapshots:
       human-id: 1.0.2
       prettier: 2.8.8
 
+  '@cloudflare/kv-asset-handler@0.3.4':
+    dependencies:
+      mime: 3.0.0
+
+  '@cloudflare/workerd-darwin-64@1.20241218.0':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20241218.0':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20241218.0':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20241218.0':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20241218.0':
+    optional: true
+
+  '@cloudflare/workers-types@4.20241218.0': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@emnapi/runtime@1.3.1':
     dependencies:
       tslib: 2.8.1
@@ -4310,6 +4698,16 @@ snapshots:
 
   '@emotion/weak-memoize@0.4.0': {}
 
+  '@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.17.19)':
+    dependencies:
+      esbuild: 0.17.19
+
+  '@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.17.19)':
+    dependencies:
+      esbuild: 0.17.19
+      escape-string-regexp: 4.0.0
+      rollup-plugin-node-polyfills: 0.2.1
+
   '@esbuild/aix-ppc64@0.19.12':
     optional: true
 
@@ -4317,6 +4715,9 @@ snapshots:
     optional: true
 
   '@esbuild/aix-ppc64@0.24.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.17.19':
     optional: true
 
   '@esbuild/android-arm64@0.19.12':
@@ -4328,6 +4729,9 @@ snapshots:
   '@esbuild/android-arm64@0.24.0':
     optional: true
 
+  '@esbuild/android-arm@0.17.19':
+    optional: true
+
   '@esbuild/android-arm@0.19.12':
     optional: true
 
@@ -4335,6 +4739,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm@0.24.0':
+    optional: true
+
+  '@esbuild/android-x64@0.17.19':
     optional: true
 
   '@esbuild/android-x64@0.19.12':
@@ -4346,6 +4753,9 @@ snapshots:
   '@esbuild/android-x64@0.24.0':
     optional: true
 
+  '@esbuild/darwin-arm64@0.17.19':
+    optional: true
+
   '@esbuild/darwin-arm64@0.19.12':
     optional: true
 
@@ -4353,6 +4763,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-arm64@0.24.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.17.19':
     optional: true
 
   '@esbuild/darwin-x64@0.19.12':
@@ -4364,6 +4777,9 @@ snapshots:
   '@esbuild/darwin-x64@0.24.0':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.17.19':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.19.12':
     optional: true
 
@@ -4371,6 +4787,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-arm64@0.24.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.17.19':
     optional: true
 
   '@esbuild/freebsd-x64@0.19.12':
@@ -4382,6 +4801,9 @@ snapshots:
   '@esbuild/freebsd-x64@0.24.0':
     optional: true
 
+  '@esbuild/linux-arm64@0.17.19':
+    optional: true
+
   '@esbuild/linux-arm64@0.19.12':
     optional: true
 
@@ -4389,6 +4811,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm64@0.24.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.17.19':
     optional: true
 
   '@esbuild/linux-arm@0.19.12':
@@ -4400,6 +4825,9 @@ snapshots:
   '@esbuild/linux-arm@0.24.0':
     optional: true
 
+  '@esbuild/linux-ia32@0.17.19':
+    optional: true
+
   '@esbuild/linux-ia32@0.19.12':
     optional: true
 
@@ -4407,6 +4835,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ia32@0.24.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.17.19':
     optional: true
 
   '@esbuild/linux-loong64@0.19.12':
@@ -4418,6 +4849,9 @@ snapshots:
   '@esbuild/linux-loong64@0.24.0':
     optional: true
 
+  '@esbuild/linux-mips64el@0.17.19':
+    optional: true
+
   '@esbuild/linux-mips64el@0.19.12':
     optional: true
 
@@ -4425,6 +4859,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-mips64el@0.24.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.17.19':
     optional: true
 
   '@esbuild/linux-ppc64@0.19.12':
@@ -4436,6 +4873,9 @@ snapshots:
   '@esbuild/linux-ppc64@0.24.0':
     optional: true
 
+  '@esbuild/linux-riscv64@0.17.19':
+    optional: true
+
   '@esbuild/linux-riscv64@0.19.12':
     optional: true
 
@@ -4443,6 +4883,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-riscv64@0.24.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.17.19':
     optional: true
 
   '@esbuild/linux-s390x@0.19.12':
@@ -4454,6 +4897,9 @@ snapshots:
   '@esbuild/linux-s390x@0.24.0':
     optional: true
 
+  '@esbuild/linux-x64@0.17.19':
+    optional: true
+
   '@esbuild/linux-x64@0.19.12':
     optional: true
 
@@ -4461,6 +4907,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-x64@0.24.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.17.19':
     optional: true
 
   '@esbuild/netbsd-x64@0.19.12':
@@ -4475,6 +4924,9 @@ snapshots:
   '@esbuild/openbsd-arm64@0.24.0':
     optional: true
 
+  '@esbuild/openbsd-x64@0.17.19':
+    optional: true
+
   '@esbuild/openbsd-x64@0.19.12':
     optional: true
 
@@ -4482,6 +4934,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-x64@0.24.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.17.19':
     optional: true
 
   '@esbuild/sunos-x64@0.19.12':
@@ -4493,6 +4948,9 @@ snapshots:
   '@esbuild/sunos-x64@0.24.0':
     optional: true
 
+  '@esbuild/win32-arm64@0.17.19':
+    optional: true
+
   '@esbuild/win32-arm64@0.19.12':
     optional: true
 
@@ -4500,6 +4958,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.24.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.17.19':
     optional: true
 
   '@esbuild/win32-ia32@0.19.12':
@@ -4511,6 +4972,9 @@ snapshots:
   '@esbuild/win32-ia32@0.24.0':
     optional: true
 
+  '@esbuild/win32-x64@0.17.19':
+    optional: true
+
   '@esbuild/win32-x64@0.19.12':
     optional: true
 
@@ -4519,6 +4983,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.24.0':
     optional: true
+
+  '@fastify/busboy@2.1.1': {}
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
@@ -4608,6 +5074,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/trace-mapping@0.3.25':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -5018,6 +5489,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/node-forge@1.3.11':
+    dependencies:
+      '@types/node': 20.17.10
+
   '@types/node@12.20.55': {}
 
   '@types/node@20.17.10':
@@ -5149,6 +5624,10 @@ snapshots:
   array-iterate@2.0.1: {}
 
   array-union@2.1.0: {}
+
+  as-table@1.0.55:
+    dependencies:
+      printable-characters: 1.0.42
 
   assertion-error@2.0.1: {}
 
@@ -5298,6 +5777,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  blake3-wasm@2.1.5: {}
+
   boolbase@1.0.0: {}
 
   boxen@8.0.1:
@@ -5333,6 +5814,13 @@ snapshots:
   camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001690: {}
+
+  capnp-ts@0.7.0:
+    dependencies:
+      debug: 4.4.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
 
   ccount@2.0.1: {}
 
@@ -5388,6 +5876,10 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.0.2
 
   ci-info@3.9.0: {}
 
@@ -5479,7 +5971,11 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  data-uri-to-buffer@2.0.2: {}
+
   dataloader@1.4.0: {}
+
+  date-fns@4.1.0: {}
 
   debug@4.4.0:
     dependencies:
@@ -5592,6 +6088,31 @@ snapshots:
       acorn: 8.14.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.2
+
+  esbuild@0.17.19:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.17.19
+      '@esbuild/android-arm64': 0.17.19
+      '@esbuild/android-x64': 0.17.19
+      '@esbuild/darwin-arm64': 0.17.19
+      '@esbuild/darwin-x64': 0.17.19
+      '@esbuild/freebsd-arm64': 0.17.19
+      '@esbuild/freebsd-x64': 0.17.19
+      '@esbuild/linux-arm': 0.17.19
+      '@esbuild/linux-arm64': 0.17.19
+      '@esbuild/linux-ia32': 0.17.19
+      '@esbuild/linux-loong64': 0.17.19
+      '@esbuild/linux-mips64el': 0.17.19
+      '@esbuild/linux-ppc64': 0.17.19
+      '@esbuild/linux-riscv64': 0.17.19
+      '@esbuild/linux-s390x': 0.17.19
+      '@esbuild/linux-x64': 0.17.19
+      '@esbuild/netbsd-x64': 0.17.19
+      '@esbuild/openbsd-x64': 0.17.19
+      '@esbuild/sunos-x64': 0.17.19
+      '@esbuild/win32-arm64': 0.17.19
+      '@esbuild/win32-ia32': 0.17.19
+      '@esbuild/win32-x64': 0.17.19
 
   esbuild@0.19.12:
     optionalDependencies:
@@ -5717,6 +6238,8 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
 
+  estree-walker@0.6.1: {}
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -5738,6 +6261,8 @@ snapshots:
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
+
+  exit-hook@2.2.1: {}
 
   expect-type@1.1.0: {}
 
@@ -5811,6 +6336,11 @@ snapshots:
 
   get-port-please@3.1.2: {}
 
+  get-source@2.0.12:
+    dependencies:
+      data-uri-to-buffer: 2.0.2
+      source-map: 0.6.1
+
   get-stream@8.0.1: {}
 
   github-slugger@2.0.0: {}
@@ -5819,7 +6349,11 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob-to-regexp@0.4.1: {}
+
   globals@11.12.0: {}
+
+  globalyzer@0.1.0: {}
 
   globby@11.1.0:
     dependencies:
@@ -5838,6 +6372,8 @@ snapshots:
       path-type: 5.0.0
       slash: 5.1.0
       unicorn-magic: 0.1.0
+
+  globrex@0.1.2: {}
 
   graceful-fs@4.2.11: {}
 
@@ -6108,6 +6644,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  itty-time@1.0.6: {}
+
   jiti@2.4.2: {}
 
   js-tokens@4.0.0: {}
@@ -6194,6 +6732,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  magic-string@0.25.9:
+    dependencies:
+      sourcemap-codec: 1.4.8
 
   magic-string@0.30.17:
     dependencies:
@@ -6671,6 +7213,25 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
+  miniflare@3.20241218.0(bufferutil@4.0.8):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      acorn: 8.14.0
+      acorn-walk: 8.3.4
+      capnp-ts: 0.7.0
+      exit-hook: 2.2.1
+      glob-to-regexp: 0.4.1
+      stoppable: 1.1.0
+      undici: 5.28.4
+      workerd: 1.20241218.0
+      ws: 8.18.0(bufferutil@4.0.8)
+      youch: 3.3.4
+      zod: 3.24.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   mlly@1.7.3:
     dependencies:
       acorn: 8.14.0
@@ -6683,6 +7244,8 @@ snapshots:
   mrmime@2.0.0: {}
 
   ms@2.1.3: {}
+
+  mustache@4.2.0: {}
 
   nanoid@3.3.8: {}
 
@@ -6833,6 +7396,8 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-to-regexp@6.3.0: {}
+
   path-type@4.0.0: {}
 
   path-type@5.0.0: {}
@@ -6889,6 +7454,8 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  printable-characters@1.0.42: {}
+
   prismjs@1.29.0: {}
 
   prompts@2.4.2:
@@ -6926,6 +7493,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  readdirp@4.0.2: {}
 
   recast@0.23.9:
     dependencies:
@@ -7095,6 +7664,20 @@ snapshots:
 
   reusify@1.0.4: {}
 
+  rollup-plugin-inject@3.0.2:
+    dependencies:
+      estree-walker: 0.6.1
+      magic-string: 0.25.9
+      rollup-pluginutils: 2.8.2
+
+  rollup-plugin-node-polyfills@0.2.1:
+    dependencies:
+      rollup-plugin-inject: 3.0.2
+
+  rollup-pluginutils@2.8.2:
+    dependencies:
+      estree-walker: 0.6.1
+
   rollup@4.29.1:
     dependencies:
       '@types/estree': 1.0.6
@@ -7129,6 +7712,11 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  selfsigned@2.4.1:
+    dependencies:
+      '@types/node-forge': 1.3.11
+      node-forge: 1.3.1
 
   semver@6.3.1: {}
 
@@ -7241,6 +7829,8 @@ snapshots:
 
   source-map@0.7.4: {}
 
+  sourcemap-codec@1.4.8: {}
+
   space-separated-tokens@2.0.2: {}
 
   spawndamnit@3.0.1:
@@ -7254,9 +7844,16 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  stacktracey@2.1.8:
+    dependencies:
+      as-table: 1.0.55
+      get-source: 2.0.12
+
   statuses@2.0.1: {}
 
   std-env@3.8.0: {}
+
+  stoppable@1.1.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -7328,6 +7925,11 @@ snapshots:
 
   term-size@2.2.1: {}
 
+  tiny-glob@0.2.9:
+    dependencies:
+      globalyzer: 0.1.0
+      globrex: 0.1.2
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -7373,6 +7975,17 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@6.19.8: {}
+
+  undici@5.28.4:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  unenv-nightly@2.0.0-20241204-140205-a5d5190:
+    dependencies:
+      defu: 6.1.4
+      ohash: 1.1.4
+      pathe: 1.1.2
+      ufo: 1.5.4
 
   unenv@1.10.0:
     dependencies:
@@ -7605,6 +8218,41 @@ snapshots:
     dependencies:
       string-width: 7.2.0
 
+  workerd@1.20241218.0:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20241218.0
+      '@cloudflare/workerd-darwin-arm64': 1.20241218.0
+      '@cloudflare/workerd-linux-64': 1.20241218.0
+      '@cloudflare/workerd-linux-arm64': 1.20241218.0
+      '@cloudflare/workerd-windows-64': 1.20241218.0
+
+  wrangler@3.99.0(@cloudflare/workers-types@4.20241218.0)(bufferutil@4.0.8):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.3.4
+      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
+      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
+      blake3-wasm: 2.1.5
+      chokidar: 4.0.3
+      date-fns: 4.1.0
+      esbuild: 0.17.19
+      itty-time: 1.0.6
+      miniflare: 3.20241218.0(bufferutil@4.0.8)
+      nanoid: 3.3.8
+      path-to-regexp: 6.3.0
+      resolve: 1.22.10
+      selfsigned: 2.4.1
+      source-map: 0.6.1
+      unenv: unenv-nightly@2.0.0-20241204-140205-a5d5190
+      workerd: 1.20241218.0
+      xxhash-wasm: 1.1.0
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20241218.0
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   wrap-ansi@9.0.0:
     dependencies:
       ansi-styles: 6.2.1
@@ -7630,6 +8278,12 @@ snapshots:
       yoctocolors: 2.1.1
 
   yoctocolors@2.1.1: {}
+
+  youch@3.3.4:
+    dependencies:
+      cookie: 0.7.2
+      mustache: 4.2.0
+      stacktracey: 2.1.8
 
   zimmerframe@1.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       astro-bun-websocket:
         specifier: workspace:*
         version: link:../packages/bun-websocket
+      astro-cloudflare-websocket:
+        specifier: workspace:*
+        version: link:../packages/cloudflare-websocket
       astro-deno-websocket:
         specifier: workspace:*
         version: link:../packages/deno-websocket

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       miniflare:
         specifier: ^3.20241106.1
         version: 3.20241218.0(bufferutil@4.0.8)
+      rollup:
+        specifier: ^4.29.1
+        version: 4.29.1
       tiny-glob:
         specifier: ^0.2.9
         version: 0.2.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,5 +4,7 @@
         # exclude the git submodules, they managed manually
         "!packages/node-websocket/withastro/adapters/**",
         "!packages/bun-websocket/NuroDev/astro-bun/**",
+        "!packages/cloudflare-websocket/withastro/adapters/**",
+        "!packages/deno-websocket/denoland/deno-astro-adapter/**"
     ]
 }

--- a/tests/cloudflare-websocket.test.ts
+++ b/tests/cloudflare-websocket.test.ts
@@ -83,7 +83,7 @@ describe("build", {
             wrangler.kill()
             throw e
         })
-    }, 6000)
+    }, 8000)
 
     afterAll(() => wrangler.kill())
 

--- a/tests/cloudflare-websocket.test.ts
+++ b/tests/cloudflare-websocket.test.ts
@@ -1,0 +1,98 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
+import { describe, beforeAll, test, expect, afterAll } from "vitest"
+import { dev, type DevServer, build } from "./utils.ts"
+import cloudflareAdapter from "astro-cloudflare-websocket"
+
+describe("dev", {
+    timeout: 1000,
+    skip: process.version.startsWith("v23.") === false
+}, () => {
+    let server: DevServer
+
+    beforeAll(async () => server = await dev("./fixtures/websocket", {
+        adapter: cloudflareAdapter()
+    }))
+
+    afterAll(() => server.stop())
+
+    test("performs upgrade", { timeout: 1000 }, async () => {
+        const ws = new WebSocket(`ws://localhost:${server.address.port}/ws`)
+        const { promise, resolve } = Promise.withResolvers<void>()
+        ws.onopen = () => ws.send("Hello")
+        ws.onmessage = (e) => {
+            ws.close()
+            expect(e.data).to.equal("olleH")
+            resolve()
+        }
+        await promise
+    })
+
+    test("endpoint can reject upgrade request", async () => {
+        const ws = new WebSocket(`ws://localhost:${server.address.port}/ws`, "unsupported-protocol")
+        const { promise, resolve } = Promise.withResolvers<void>()
+        ws.onerror = e => {
+            expect("message" in e && e.message).to.equal("Received network error or non-101 status code.")
+            resolve()
+        }
+        await promise
+    })
+
+    test("route can handle non-upgrade requests", async () => {
+        const response = await fetch(`http://localhost:${server.address.port}/ws`)
+        expect(response.status).to.equal(426)
+        expect(response.headers.get("X-Error")).to.equal("Non Upgrade Request")
+    })
+})
+
+describe("build", {
+    timeout: 500,
+    skip: process.version.startsWith("v23.") === false
+}, () => {
+    let wrangler: ChildProcessWithoutNullStreams
+
+    beforeAll(async () => {
+        const fixture = await build("./fixtures/websocket", {
+            adapter: cloudflareAdapter()
+        })
+        wrangler = spawn("pnpm", [ ..."dlx wrangler pages dev --compatibility-date 2024-12-21".split(" "), fixture.outDir ])
+        
+        const { promise, resolve, reject } = Promise.withResolvers<void>()
+        wrangler.stdout.on("data", function onData(data) {
+            if(data.toString() === "[wrangler:inf] Ready on http://127.0.0.1:8788\n") {
+                resolve()
+            }
+        })
+        wrangler.stderr.on("data", data => reject(data.toString()))
+        wrangler.on("error", error => reject(error))
+        setTimeout(() => reject(new Error("Timeout")), 6000)
+        await promise.catch(e => {
+            wrangler.kill()
+            throw e
+        })
+    }, 6000)
+
+    afterAll(() => wrangler.kill())
+
+    test("performs upgrade", async () => {
+        const ws = new WebSocket(`ws://localhost:8788/ws`)
+        const { promise, resolve, reject } = Promise.withResolvers<void>()
+        ws.onopen = () => ws.send("Hello")
+        ws.onmessage = (e) => {
+            ws.close()
+            expect(e.data).to.equal("olleH")
+            resolve()
+        }
+        ws.onerror = reject
+        await promise
+    })
+
+    test("endpoint can reject upgrade request", async () => {
+        const ws = new WebSocket(`ws://localhost:8788/ws`, "unsupported-protocol")
+        const { promise, resolve } = Promise.withResolvers<void>()
+        ws.onerror = e => {
+            expect("message" in e && e.message).to.equal("Received network error or non-101 status code.")
+            resolve()
+        }
+        await promise
+    })
+})

--- a/tests/package.json
+++ b/tests/package.json
@@ -7,6 +7,7 @@
         "@astrojs/node": "9",
         "astro": "5",
         "astro-bun-websocket": "workspace:*",
+        "astro-cloudflare-websocket": "workspace:*",
         "astro-deno-websocket": "workspace:*",
         "astro-node-websocket": "workspace:*",
         "cheerio": "1.0.0-rc.12",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "astro/tsconfigs/strict",
     "exclude": [
         "packages/bun-websocket",
+        "packages/cloudflare-websocket",
         "packages/deno-websocket",
         "packages/node-websocket",
     ],


### PR DESCRIPTION
# What's added?
- An adapter for cloudflare based on `@astrojs/cloudflare` with support for websockets added via `ctx.locals.upgradeWebSocket`.
- Same API as `astro-node-websocket`, `astro-bun-websocket`, and `astro-deno-websocket.`

# Documentation
- [x] Readme

# Testing
- [x] `cloudflare-websocket.test.ts`
- [ ] "script will never generate a response" errors when the client closes the connection. Known issue, reported in https://github.com/cloudflare/workers-sdk/issues/5433, and remediation was documented at [Errors and exceptions
 | Cloudflare Workers docs](https://developers.cloudflare.com/workers/observability/errors/#cause-2-websocket-connections-that-are-never-closed), but the error remains despite the remediation.