### PR TITLE
fix(dynamic-import): remove `env.d.ts` processing

### DIFF
--- a/.changeset/gorgeous-jokes-argue.md
+++ b/.changeset/gorgeous-jokes-argue.md
@@ -1,0 +1,5 @@
+---
+"astro-dynamic-import": patch
+---
+
+Fixes an issue where the integration attempted to read a file (env.d.ts) that does not exist in Astro 5.x projects.

--- a/packages/dynamic-import/integration.ts
+++ b/packages/dynamic-import/integration.ts
@@ -11,7 +11,7 @@ export default function (_?: Options): AstroIntegration {
     return {
         name: "astro-dynamic-import",
         hooks: {
-            "astro:config:setup" ({ config, updateConfig, logger }) {
+            "astro:config:setup" ({ config, updateConfig }) {
                 const srcDirName = path.relative(url.fileURLToPath(config.root), url.fileURLToPath(config.srcDir)).replaceAll("\\", "/")
                 updateConfig({ vite: { 
                   optimizeDeps: {
@@ -29,43 +29,8 @@ export default function (_?: Options): AstroIntegration {
                             `export const lookupMap = import.meta.glob('/${srcDirName}/components/**/*.astro', { query: { ${PROPAGATED_ASSET_FLAG}: true } })\n`
                         }
                     }
-                }, {
-                    name: "astro-dynamic-import/vite/types",
-                    enforce: "post",
-                    async config() {
-                        injectEnvDTS(config, logger, "astro-dynamic-import/client")
-                    }
-                }] } })
+                }]}})
             }
         }
     }
-}
-
-function injectEnvDTS(config: AstroConfig, logger: AstroIntegrationLogger, specifier: URL | string) {
-    const envDTsPath = url.fileURLToPath(new URL("env.d.ts", config.srcDir))
-    
-    if (specifier instanceof URL) {
-        specifier = url.fileURLToPath(specifier)
-        specifier = path.relative(url.fileURLToPath(config.srcDir), specifier)
-        specifier = specifier.replaceAll("\\", "/")
-    }
-    
-    let envDTsContents = fs.readFileSync(envDTsPath, "utf-8")
-    
-    if (envDTsContents.includes(`/// <reference types='${specifier}' />`)) { return }
-    if (envDTsContents.includes(`/// <reference types="${specifier}" />`)) { return }
-    
-    const newEnvDTsContents = envDTsContents.replace(
-        `/// <reference types='astro/client' />`,
-        `/// <reference types='astro/client' />\n/// <reference types='${specifier}' />\n`
-    ).replace(
-        `/// <reference types="astro/client" />`,
-        `/// <reference types="astro/client" />\n/// <reference types="${specifier}" />\n`
-    )
-    
-    // the odd case where the user changed the reference to astro/client
-    if (newEnvDTsContents === envDTsContents) { return }
-    
-    fs.writeFileSync(envDTsPath, newEnvDTsContents)
-    logger.info("Updated env.d.ts types")
 }

--- a/packages/dynamic-import/integration.ts
+++ b/packages/dynamic-import/integration.ts
@@ -1,7 +1,6 @@
 import url from "node:url"
 import path from "node:path"
-import fs from "node:fs"
-import type { AstroConfig, AstroIntegration, AstroIntegrationLogger } from "astro"
+import type { AstroIntegration } from "astro"
 import { PROPAGATED_ASSET_FLAG } from "./node_modules/astro/dist/content/consts.js"
 import "./types.d.ts"
 


### PR DESCRIPTION
# Changes
- Fixes https://github.com/lilnasy/gratelets/issues/100#issuecomment-2575721290
- Since 2.0, env.d.ts is left alone and the necessary global types are imported directly into the declaration, and they become ambient when the integration is imported into the user project.
- This removes the code for the previous approach, which errors when `env.d.ts` is not present.

# Testing
- Existing tests should pass

# Docs
- Bugfix, does not impact usage.