### PR TITLE
feat(typed api): client api for server

### DIFF
--- a/.changeset/breezy-geckos-occur.md
+++ b/.changeset/breezy-geckos-occur.md
@@ -1,0 +1,17 @@
+---
+"astro-typed-api": minor
+---
+
+Typed API routes are now reusable throughout your project!
+
+You can define your main application logic in API routes, and then use it for server-side rendering static HTML by calling it from the frontmatter of your pages.
+
+```astro
+---
+import { api } from "astro-typed-api/client"
+const results = await api.search.GET.fetch({ query: Astro.params.query })
+---
+{results.map(result => <div>{result.title}</div>)}
+```
+
+The `cookies`, `headers`, `locals`, and `request` objects are automatically populated with the current request's values.

--- a/packages/typed-api/integration.ts
+++ b/packages/typed-api/integration.ts
@@ -36,12 +36,22 @@ export default function (options?: Partial<Options>): AstroIntegration {
                     vite: {
                         define: {
                             "import.meta.env._TRAILING_SLASH": JSON.stringify(config.trailingSlash),
-                            "import.meta.env.TYPED_API_SERIALIZATION": JSON.stringify(options?.serialization)
+                            "import.meta.env.TYPED_API_SERIALIZATION": JSON.stringify(options?.serialization),
+                            "import.meta.env._API_DIR": JSON.stringify(url.fileURLToPath(new URL("pages/api/", config.srcDir)))
                         },
                         ssr: {
                             // this package is published as uncompiled typescript, which we need vite to process
                             noExternal: ["astro-typed-api"]
-                        }
+                        },
+                        plugins: [{
+                            name: "astro-typed-api",
+                            enforce: "pre",
+                            resolveId(id) {
+                                if (id === "astro-typed-api/client" && this.environment.config.consumer === "server") {
+                                    return url.fileURLToPath(new URL("runtime/server-client.ts", import.meta.url))
+                                }
+                            }
+                        }]
                     }
                 })
             },

--- a/packages/typed-api/runtime/api-context-storage.ts
+++ b/packages/typed-api/runtime/api-context-storage.ts
@@ -1,0 +1,4 @@
+import type { APIContext } from "astro"
+import { AsyncLocalStorage } from "node:async_hooks"
+
+export const apiContextStorage = new AsyncLocalStorage<APIContext>()

--- a/packages/typed-api/runtime/middleware.ts
+++ b/packages/typed-api/runtime/middleware.ts
@@ -1,13 +1,14 @@
-import type { MiddlewareNext } from "astro"
+import type { APIContext, MiddlewareNext } from "astro"
 import { ProcedureFailed, UnusableRequest, ValidationFailed } from "./errors.server.ts"
+import { apiContextStorage } from "./api-context-storage.ts"
 
 /**
  * This middleware handles errors that occured due to malformed
  * requests and returns an appropriate error response.
  */
-export async function onRequest(_: unknown, next: MiddlewareNext) {
+export async function onRequest(context: APIContext, next: MiddlewareNext) {
     try {
-        return await next()
+        return await apiContextStorage.run(context, next)
     } catch (error) {
         if (
             error instanceof UnusableRequest ||

--- a/packages/typed-api/runtime/server-client-internals.ts
+++ b/packages/typed-api/runtime/server-client-internals.ts
@@ -1,0 +1,85 @@
+/**
+ * Includes code for the `api` object when it is imported in a server module.
+ * 
+ * Implements a shorter circuit because both the caller and the
+ * called function are in the same process.
+ * 
+ * The current request's APIContext is reused for typed api context.
+ * 
+ * Request options (headers, etc) are completely ignored.
+ * 
+ * No serialization/deserialization is involved.
+ * 
+ * Validation is not performed, although it can be implemented.
+ * 
+ * Custom error handling is not going to work, the 500 response
+ * object is returned as-is.
+ * 
+ * All of this is probably okay for most use-cases calling api
+ * from a server module.
+ * 
+ * If it is not okay, the behavior can be made more sophisticated
+ * as use-cases require.
+ */
+
+import { InvalidUsage } from "./errors.client.ts"
+import { apiContextStorage } from "./api-context-storage.ts"
+import type { TypedAPIContext } from "./server.ts"
+import { ErrorResponse } from "./error-response.ts"
+import type { APIContext } from "astro"
+
+const apiGlob = import.meta.glob(import.meta.env._API_DIR + "**/*.{ts,mts}")
+
+export const proxyHandler: ProxyHandler<Function> & { path: string[] } = {
+    path: [],
+    get(target, prop) {
+        if (typeof prop === "symbol") {
+            throw new TypeError(`The typed API client cannot be keyed with ${String(prop)}.`)
+        }
+        return new Proxy(target, {
+            ...proxyHandler,
+            // @ts-expect-error "Object literal may only specify known properties, and 'path'
+            // does not exist in type 'ProxyHandler<() => void>'.ts(2353)" The proxy handler
+            // can have additional properties, and it becomes available as 'this' in the traps.
+            path: [
+                ...this.path,
+                prop
+            ]
+        })
+    },
+    async apply(target, thisArg, argArray) {
+        const { path } = this
+        const callType = path[path.length - 1]
+        const method = path[path.length - 2]
+        if (callType === "fetch") {
+            const endpoint = path.slice(0, -2).join("/")
+            const matches: string[] = []
+            for (const api in apiGlob) {
+                if (api.includes(endpoint)) {
+                    matches.push(api)
+                }
+            }
+            if (matches.length === 0) {
+                throw new Error(`No API endpoint found for ${endpoint}`)
+            }
+            const shortestMatch = matches.sort((a, b) => a.length - b.length)[0]
+            const api: any = await apiGlob[shortestMatch]()
+            const astroApiContext = apiContextStorage.getStore()!
+            const typedApiContext: TypedAPIContext = Object.setPrototypeOf(
+                {
+                    response: {
+                        status: 200,
+                        statusText: "OK",
+                        headers: new Headers
+                    },
+                    error(details, response) {
+                        return new ErrorResponse(details, response)
+                    }
+                } satisfies Omit<TypedAPIContext, keyof APIContext>,
+                astroApiContext
+            )
+            return await api[method].fetch(argArray[0], typedApiContext)
+        }
+        throw new InvalidUsage("incorrect call", callType)
+    },
+}

--- a/packages/typed-api/runtime/server-client.ts
+++ b/packages/typed-api/runtime/server-client.ts
@@ -1,0 +1,5 @@
+import { proxyTarget } from "./client-internals.ts"
+import { proxyHandler } from "./server-client-internals.ts"
+export { InvalidUsage, NetworkError, UnusableResponse, CustomError } from "./errors.client.ts"
+
+export const api = new Proxy(proxyTarget, proxyHandler)

--- a/packages/typed-api/runtime/server-internals.ts
+++ b/packages/typed-api/runtime/server-internals.ts
@@ -85,12 +85,15 @@ export function createApiRoute(handler: TypedAPIHandler<any, any>): APIRoute {
             writable: false
         })
 
-        const context: TypedAPIContext = Object.assign(ctx, {
-            response,
-            error(details, response) {
-                return new ErrorResponse(details, response)
-            }
-        } satisfies Omit<TypedAPIContext, keyof APIContext>)
+        const context: TypedAPIContext = Object.setPrototypeOf(
+            {
+                response,
+                error(details, response) {
+                    return new ErrorResponse(details, response)
+                }
+            } satisfies Omit<TypedAPIContext, keyof APIContext>,
+            ctx
+        )
 
         let output: any
         try {


### PR DESCRIPTION
- Implements #130
- Implements a shorter circuit because both the caller and the called function are running in the same place.
- The current request's APIContext is reused for typed api context.
- Request options (headers, etc) provided to `fetch()` are completely ignored since there is going to be no HTTP request.
- No serialization/deserialization is involved.
- Validation is not performed, although it can be implemented.
- Custom error handling is not going to work, the 500 response object is returned as-is.
- All of this is probably okay for most use-cases calling api from a server module.
- If it is not okay, the behavior can be made more sophisticated as use-cases require.
